### PR TITLE
Add Neo4j graph RAG pipeline

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
     "langchain-ollama==0.2.1",
     "langchain-openai==0.2.0",
     "langchain==0.3.11",
+    "neo4j==5.27.0",
     "mistralai==1.5.0",
     "smolagents[mcp]==1.21.1",
     "langchain-huggingface==0.1.2",

--- a/src/raglight/config/graph_rag_config.py
+++ b/src/raglight/config/graph_rag_config.py
@@ -1,0 +1,18 @@
+from dataclasses import dataclass, field
+from typing import Optional
+
+from ..config.settings import Settings
+
+
+@dataclass(kw_only=True)
+class GraphRAGConfig:
+    uri: str
+    username: str
+    password: str
+    database: Optional[str] = None
+    cypher_prompt: Optional[str] = None
+    api_base: str = field(default=Settings.DEFAULT_OLLAMA_CLIENT)
+    llm: str = field(default=Settings.DEFAULT_LLM)
+    provider: str = field(default=Settings.OLLAMA)
+    system_prompt: str = field(default=Settings.DEFAULT_SYSTEM_PROMPT)
+    stream: bool = field(default=False)

--- a/src/raglight/rag/__init__.py
+++ b/src/raglight/rag/__init__.py
@@ -1,0 +1,2 @@
+from .graph_rag import GraphRAG
+from .graph_rag_api import GraphRAGPipeline

--- a/src/raglight/rag/builder.py
+++ b/src/raglight/rag/builder.py
@@ -15,11 +15,13 @@ from ..vectorstore.vector_store import VectorStore
 from ..vectorstore.chroma import ChromaVS
 from ..config.settings import Settings
 from .rag import RAG
+from .graph_rag import GraphRAG
 from ..rat.rat import RAT
 from ..embeddings.embeddings_model import EmbeddingsModel
 from ..embeddings.huggingface_embeddings import HuggingfaceEmbeddingsModel
 from ..embeddings.gemini_embeddings import GeminiEmbeddingsModel
 from ..llm.gemini_model import GeminiModel
+from langchain_community.graphs import Neo4jGraph
 
 
 class Builder:
@@ -47,6 +49,8 @@ class Builder:
         self.reasoning_llm: Optional[LLM] = None
         self.rag: Optional[RAG] = None
         self.rat: Optional[RAT] = None
+        self.graph_store: Optional[Neo4jGraph] = None
+        self.graph_rag: Optional[GraphRAG] = None
 
     def with_embeddings(self, type: str, **kwargs) -> Builder:
         """
@@ -154,6 +158,30 @@ class Builder:
         logging.info("✅ LLM created")
         return self
 
+    def with_graph_store(
+        self,
+        uri: str,
+        username: str,
+        password: str,
+        database: Optional[str] = None,
+    ) -> Builder:
+        """
+        Configures the Neo4j graph store for Graph RAG.
+
+        Args:
+            uri (str): The Neo4j connection URI.
+            username (str): Username for authentication.
+            password (str): Password for authentication.
+            database (Optional[str]): Optional database name.
+        """
+
+        logging.info("⏳ Creating a Neo4j Graph store...")
+        self.graph_store = Neo4jGraph(
+            url=uri, username=username, password=password, database=database
+        )
+        logging.info("✅ Neo4j Graph store created")
+        return self
+
     def with_reasoning_llm(self, type: str, **kwargs) -> Builder:
         """
         Configures the reasoning large language model (LLM) for RAT pipelines.
@@ -205,6 +233,38 @@ class Builder:
         )
         logging.info("✅ RAG pipeline created")
         return self.rag
+
+    def build_graph_rag(
+        self, cypher_prompt: Optional[str] = None, stream: bool = False
+    ) -> GraphRAG:
+        """
+        Builds the Graph RAG pipeline using the configured LLM and Neo4j graph.
+
+        Args:
+            cypher_prompt (Optional[str]): Custom prompt guiding Cypher generation.
+            stream (bool): Enable streaming generation when supported by the LLM.
+
+        Returns:
+            GraphRAG: The configured Graph RAG pipeline instance.
+
+        Raises:
+            ValueError: If the Neo4j graph store or LLM is not configured.
+        """
+
+        if self.graph_store is None:
+            raise ValueError("Graph store is required for Graph RAG")
+        if self.llm is None:
+            raise ValueError("LLM is required")
+
+        logging.info("⏳ Building the Graph RAG pipeline...")
+        self.graph_rag = GraphRAG(
+            llm=self.llm,
+            graph=self.graph_store,
+            cypher_prompt=cypher_prompt,
+            stream=stream,
+        )
+        logging.info("✅ Graph RAG pipeline created")
+        return self.graph_rag
 
     def build_rat(self, reflection: int = 1, k: int = Settings.DEFAULT_K) -> RAT:
         """

--- a/src/raglight/rag/graph_rag.py
+++ b/src/raglight/rag/graph_rag.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+import json
+from typing import Any, Dict
+from typing_extensions import TypedDict
+
+from langgraph.graph import START, StateGraph
+from langchain_community.graphs import Neo4jGraph
+
+from ..llm.llm import LLM
+
+
+class GraphState(TypedDict):
+    """Represents the state of the Graph RAG process."""
+
+    question: str
+    cypher_query: str
+    graph_result: str
+    answer: str
+
+
+class GraphRAG:
+    """Graph-based Retrieval-Augmented Generation powered by Neo4j."""
+
+    DEFAULT_CYPHER_PROMPT: str = (
+        "You are an expert Neo4j engineer. "
+        "Generate a Cypher query that answers the user's question using the provided schema. "
+        "Return only the Cypher query without explanations."
+    )
+
+    def __init__(
+        self,
+        llm: LLM,
+        graph: Neo4jGraph,
+        cypher_prompt: str | None = None,
+        stream: bool = False,
+    ) -> None:
+        self.llm = llm
+        self.graph = graph
+        self.cypher_prompt = cypher_prompt or self.DEFAULT_CYPHER_PROMPT
+        self.stream = stream
+        self.workflow: Any = self._create_graph()
+
+    def generate_cypher(self, state: Dict[str, str]) -> Dict[str, str]:
+        prompt = {
+            "instruction": self.cypher_prompt,
+            "schema": self.graph.schema,
+            "question": state["question"],
+        }
+        cypher_query = self.llm.generate(prompt)
+        return {"cypher_query": cypher_query, "question": state["question"]}
+
+    def run_cypher(self, state: Dict[str, str]) -> Dict[str, str]:
+        result = self.graph.query(state["cypher_query"])
+        return {
+            "question": state["question"],
+            "cypher_query": state["cypher_query"],
+            "graph_result": self._format_graph_result(result),
+        }
+
+    def generate_answer(self, state: Dict[str, str]) -> Dict[str, Any]:
+        prompt = {
+            "question": state["question"],
+            "cypher_query": state["cypher_query"],
+            "graph_result": state["graph_result"],
+        }
+        if self.stream and hasattr(self.llm, "generate_streaming"):
+            response = self.llm.generate_streaming(prompt)  # type: ignore[attr-defined]
+        else:
+            response = self.llm.generate(prompt)
+        return {"answer": response}
+
+    def _create_graph(self) -> Any:
+        graph_builder = StateGraph(GraphState).add_sequence(
+            [self.generate_cypher, self.run_cypher, self.generate_answer]
+        )
+        graph_builder.add_edge(START, "generate_cypher")
+        return graph_builder.compile()
+
+    def generate(self, question: str) -> Any:
+        state = {"question": question}
+        response = self.workflow.invoke(state)
+        return response["answer"]
+
+    @staticmethod
+    def _format_graph_result(result: Any) -> str:
+        if isinstance(result, str):
+            return result
+        if isinstance(result, list):
+            return "\n".join(json.dumps(row, default=str) for row in result)
+        if isinstance(result, dict):
+            return json.dumps(result, default=str)
+        return str(result)

--- a/src/raglight/rag/graph_rag_api.py
+++ b/src/raglight/rag/graph_rag_api.py
@@ -1,0 +1,28 @@
+from ..config.graph_rag_config import GraphRAGConfig
+from ..rag.builder import Builder
+from ..rag.graph_rag import GraphRAG
+
+
+class GraphRAGPipeline:
+    """Pipeline wrapper to run Graph RAG with Neo4j."""
+
+    def __init__(self, config: GraphRAGConfig) -> None:
+        self.graph_rag: GraphRAG = (
+            Builder()
+            .with_llm(
+                config.provider,
+                model_name=config.llm,
+                system_prompt=config.system_prompt,
+                api_base=config.api_base,
+            )
+            .with_graph_store(
+                uri=config.uri,
+                username=config.username,
+                password=config.password,
+                database=config.database,
+            )
+            .build_graph_rag(cypher_prompt=config.cypher_prompt, stream=config.stream)
+        )
+
+    def generate(self, question: str):
+        return self.graph_rag.generate(question)


### PR DESCRIPTION
## Summary
- add a Neo4j-backed Graph RAG implementation using LangGraph
- extend the builder with Neo4j graph store support and a pipeline wrapper plus config
- include Neo4j dependency needed to run graph-based retrieval

## Testing
- python -m compileall src

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f157d3fc883318142d77b0b19b074)