### PR TITLE
Add Vue documentation site for RAGLight

### DIFF
--- a/docs-site/index.html
+++ b/docs-site/index.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>RAGLight | Documentation</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/main.js"></script>
+  </body>
+</html>

--- a/docs-site/package.json
+++ b/docs-site/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "raglight-docs-site",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "vue": "^3.4.21"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-vue": "^5.0.0",
+    "vite": "^5.2.0"
+  }
+}

--- a/docs-site/src/App.vue
+++ b/docs-site/src/App.vue
@@ -1,0 +1,135 @@
+<template>
+  <div>
+    <NavBar />
+    <main>
+      <HeroSection />
+      <FeatureGrid :features="features" />
+      <ContentSection
+        title="Composable building blocks"
+        subtitle="Craft modular RAG pipelines that stay maintainable as your stack grows."
+      >
+        <div class="grid" style="grid-template-columns: repeat(auto-fit, minmax(240px, 1fr)); margin-top: 24px;">
+          <SectionCard
+            v-for="card in architecture"
+            :key="card.title"
+            :title="card.title"
+            :description="card.description"
+            :tag="card.tag"
+          />
+        </div>
+      </ContentSection>
+
+      <Timeline :steps="timeline" />
+
+      <ContentSection
+        title="Batteries included documentation"
+        subtitle="Get started quickly with templates for ingestion, memory, retrieval, and evaluation."
+      >
+        <div class="panel" style="padding: 28px; display: grid; gap: 14px;">
+          <div v-for="guide in guides" :key="guide.title" class="guide">
+            <div style="display: flex; align-items: center; gap: 12px;">
+              <span class="badge" style="background: rgba(56,189,248,0.1); color: var(--text-primary); border-color: rgba(56,189,248,0.3);">
+                {{ guide.category }}
+              </span>
+              <h3 style="margin: 0; font-size: 18px;">{{ guide.title }}</h3>
+            </div>
+            <p class="subtle" style="margin: 6px 0 0 0;">{{ guide.description }}</p>
+          </div>
+        </div>
+      </ContentSection>
+
+      <CTASection />
+    </main>
+    <FooterSection />
+  </div>
+</template>
+
+<script setup>
+import NavBar from './components/NavBar.vue'
+import HeroSection from './components/HeroSection.vue'
+import FeatureGrid from './components/FeatureGrid.vue'
+import ContentSection from './components/ContentSection.vue'
+import SectionCard from './components/SectionCard.vue'
+import Timeline from './components/Timeline.vue'
+import CTASection from './components/CTASection.vue'
+import FooterSection from './components/FooterSection.vue'
+
+const features = [
+  {
+    title: 'Production grade RAG',
+    description: 'Composable pipelines for ingestion, retrievers, memory, evaluation, and tracing.',
+    icon: '⚡'
+  },
+  {
+    title: 'Bring your providers',
+    description: 'Use your preferred vector stores, LLMs, and orchestrators without boilerplate.',
+    icon: '🔌'
+  },
+  {
+    title: 'Observability built-in',
+    description: 'Tracing hooks, metrics, and evaluation loops to keep conversations reliable.',
+    icon: '📈'
+  },
+  {
+    title: 'Python first',
+    description: 'Opinionated project structure with type hints, tests, and examples ready to run.',
+    icon: '🐍'
+  }
+]
+
+const architecture = [
+  {
+    title: 'Retrieval orchestration',
+    description: 'Hybrid, semantic, or keyword retrieval made pluggable with shared interfaces.',
+    tag: 'Retrievers'
+  },
+  {
+    title: 'Memory and state',
+    description: 'Session memory primitives that keep interactions contextual and auditable.',
+    tag: 'Memory'
+  },
+  {
+    title: 'Data pipelines',
+    description: 'Chunking, embedding, and indexing flows that you can extend with your own nodes.',
+    tag: 'Ingestion'
+  },
+  {
+    title: 'Evaluation',
+    description: 'Scenarios, prompts, and scoring hooks to validate changes before you ship.',
+    tag: 'Quality'
+  }
+]
+
+const timeline = [
+  {
+    title: 'Start with the CLI',
+    detail: 'Bootstrap a new project with templates for ingestion, chat, and evaluation flows.'
+  },
+  {
+    title: 'Wire your data',
+    detail: 'Connect your data sources and embed them with the providers you already trust.'
+  },
+  {
+    title: 'Ship safely',
+    detail: 'Trace interactions, benchmark outputs, and iterate with confidence using RAGLight utilities.'
+  }
+]
+
+const guides = [
+  {
+    category: 'Quickstart',
+    title: 'Install RAGLight and explore the examples',
+    description: 'Spin up the CLI, ingest a sample corpus, and ship a first retrieval-augmented endpoint.'
+  },
+  {
+    category: 'Architecture',
+    title: 'Understand the building blocks',
+    description: 'Learn how retrievers, memory, evaluation, and tracing fit together in a clean project layout.'
+  },
+  {
+    category: 'Production',
+    title: 'Deploy with observability',
+    description: 'Use tracing hooks and evaluation suites to keep deployments stable in production.'
+  }
+]
+</script>

--- a/docs-site/src/assets/base.css
+++ b/docs-site/src/assets/base.css
@@ -1,0 +1,106 @@
+:root {
+  --bg-primary: #0b0d17;
+  --bg-secondary: #0f172a;
+  --bg-panel: #111827;
+  --accent: #7c3aed;
+  --accent-2: #38bdf8;
+  --text-primary: #e2e8f0;
+  --text-secondary: #94a3b8;
+  --card-border: rgba(255, 255, 255, 0.06);
+  --shadow: 0 15px 60px rgba(0, 0, 0, 0.35);
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  background: radial-gradient(circle at 20% 20%, rgba(124, 58, 237, 0.08), transparent 25%),
+    radial-gradient(circle at 80% 0%, rgba(56, 189, 248, 0.12), transparent 30%),
+    var(--bg-primary);
+  color: var(--text-primary);
+  min-height: 100%;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background: transparent;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+section {
+  padding: 96px 0;
+}
+
+.container {
+  width: min(1200px, 90vw);
+  margin: 0 auto;
+}
+
+.panel {
+  background: linear-gradient(145deg, rgba(255, 255, 255, 0.02), rgba(255, 255, 255, 0.01));
+  border: 1px solid var(--card-border);
+  border-radius: 24px;
+  box-shadow: var(--shadow);
+}
+
+.button {
+  display: inline-flex;
+  align-items: center;
+  gap: 12px;
+  padding: 14px 20px;
+  border-radius: 12px;
+  border: 1px solid transparent;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 150ms ease, box-shadow 150ms ease, border-color 150ms ease;
+}
+
+.button.primary {
+  background: linear-gradient(135deg, var(--accent), var(--accent-2));
+  color: #0b0d17;
+  box-shadow: 0 10px 35px rgba(124, 58, 237, 0.35);
+}
+
+.button.secondary {
+  background: transparent;
+  border-color: var(--card-border);
+  color: var(--text-primary);
+}
+
+.button:hover {
+  transform: translateY(-2px);
+}
+
+.grid {
+  display: grid;
+  gap: 20px;
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 12px;
+  border-radius: 999px;
+  background: rgba(124, 58, 237, 0.08);
+  color: var(--accent-2);
+  font-weight: 600;
+  border: 1px solid rgba(124, 58, 237, 0.2);
+}
+
+.subtle {
+  color: var(--text-secondary);
+}
+
+@media (max-width: 800px) {
+  section {
+    padding: 72px 0;
+  }
+
+  .container {
+    width: min(1000px, 92vw);
+  }
+}

--- a/docs-site/src/components/CTASection.vue
+++ b/docs-site/src/components/CTASection.vue
@@ -1,0 +1,46 @@
+<template>
+  <section id="get-started">
+    <div class="container">
+      <div class="panel cta">
+        <div>
+          <div class="badge">Ready to build?</div>
+          <h2>Start your next RAG experience with RAGLight.</h2>
+          <p class="subtle">
+            Clean architecture, batteries-included utilities, and documentation to help you ship faster.
+          </p>
+        </div>
+        <div class="cta__actions">
+          <a class="button primary" href="https://pypi.org/project/raglight/" target="_blank" rel="noreferrer">
+            Install from PyPI
+          </a>
+          <a class="button secondary" href="https://github.com/anthodev/raglight" target="_blank" rel="noreferrer">
+            View repository
+          </a>
+        </div>
+      </div>
+    </div>
+  </section>
+</template>
+
+<style scoped>
+.cta {
+  padding: 28px;
+  display: grid;
+  gap: 18px;
+  align-items: center;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  border-radius: 20px;
+}
+
+.cta__actions {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
+h2 {
+  margin: 8px 0 0 0;
+  font-size: clamp(26px, 3vw, 32px);
+}
+</style>

--- a/docs-site/src/components/ContentSection.vue
+++ b/docs-site/src/components/ContentSection.vue
@@ -1,0 +1,43 @@
+<template>
+  <section :id="sectionId">
+    <div class="container">
+      <div class="section__header">
+        <h2>{{ title }}</h2>
+        <p class="subtle">{{ subtitle }}</p>
+      </div>
+      <div>
+        <slot />
+      </div>
+    </div>
+  </section>
+</template>
+
+<script setup>
+const props = defineProps({
+  title: {
+    type: String,
+    required: true
+  },
+  subtitle: {
+    type: String,
+    required: true
+  },
+  sectionId: {
+    type: String,
+    default: ''
+  }
+})
+</script>
+
+<style scoped>
+h2 {
+  margin: 0 0 8px 0;
+  font-size: clamp(28px, 3vw, 36px);
+}
+
+.section__header {
+  display: grid;
+  gap: 6px;
+  margin-bottom: 18px;
+}
+</style>

--- a/docs-site/src/components/FeatureGrid.vue
+++ b/docs-site/src/components/FeatureGrid.vue
@@ -1,0 +1,57 @@
+<template>
+  <section id="features">
+    <div class="container">
+      <div class="section__header">
+        <h2>What makes RAGLight different?</h2>
+        <p class="subtle">Focused primitives that keep your retrieval augmented applications fast and maintainable.</p>
+      </div>
+      <div class="grid" style="grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));">
+        <div v-for="feature in features" :key="feature.title" class="panel feature">
+          <span class="feature__icon">{{ feature.icon }}</span>
+          <h3>{{ feature.title }}</h3>
+          <p class="subtle">{{ feature.description }}</p>
+        </div>
+      </div>
+    </div>
+  </section>
+</template>
+
+<script setup>
+defineProps({
+  features: {
+    type: Array,
+    required: true
+  }
+})
+</script>
+
+<style scoped>
+h2 {
+  margin: 0 0 12px 0;
+  font-size: clamp(28px, 3vw, 36px);
+}
+
+.section__header {
+  display: grid;
+  gap: 6px;
+  margin-bottom: 24px;
+}
+
+.feature {
+  padding: 22px;
+  border-radius: 18px;
+  display: grid;
+  gap: 8px;
+}
+
+.feature__icon {
+  font-size: 24px;
+  width: 48px;
+  height: 48px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 12px;
+  background: rgba(124, 58, 237, 0.14);
+}
+</style>

--- a/docs-site/src/components/FooterSection.vue
+++ b/docs-site/src/components/FooterSection.vue
@@ -1,0 +1,49 @@
+<template>
+  <footer class="footer" id="docs">
+    <div class="container footer__content">
+      <div>
+        <div class="nav__brand">RAGLight</div>
+        <p class="subtle">Documentation and examples crafted for modern retrieval augmented applications.</p>
+      </div>
+      <div class="footer__links">
+        <a href="https://github.com/anthodev/raglight" target="_blank" rel="noreferrer">GitHub</a>
+        <a href="https://pypi.org/project/raglight/" target="_blank" rel="noreferrer">PyPI</a>
+        <a href="#features">Features</a>
+        <a href="#get-started">Get started</a>
+      </div>
+    </div>
+  </footer>
+</template>
+
+<style scoped>
+.footer {
+  padding: 32px 0;
+  border-top: 1px solid var(--card-border);
+  background: rgba(15, 23, 42, 0.9);
+}
+
+.footer__content {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 14px;
+}
+
+.footer__links {
+  display: flex;
+  gap: 16px;
+  flex-wrap: wrap;
+  color: var(--text-secondary);
+}
+
+.footer__links a:hover {
+  color: var(--text-primary);
+}
+
+@media (max-width: 800px) {
+  .footer__content {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+}
+</style>

--- a/docs-site/src/components/HeroSection.vue
+++ b/docs-site/src/components/HeroSection.vue
@@ -1,0 +1,72 @@
+<template>
+  <section class="hero" id="top">
+    <div class="container hero__content">
+      <div class="badge">Modern RAG framework</div>
+      <h1>Build reliable retrieval augmented apps faster with RAGLight.</h1>
+      <p class="subtle">
+        A concise framework for shipping production-grade RAG: ingestion, retrievers, memory, evaluation, and
+        observability — ready to compose with your stack.
+      </p>
+      <div class="hero__actions">
+        <a class="button primary" href="#get-started">Get started</a>
+        <a class="button secondary" href="https://github.com/anthodev/raglight" target="_blank" rel="noreferrer">
+          Explore on GitHub
+        </a>
+      </div>
+      <div class="hero__cards">
+        <div class="panel hero__card">
+          <div class="hero__pill">CLI</div>
+          <h3>Spin up a RAG workspace</h3>
+          <p class="subtle">Use the CLI to scaffold ingestion, chat, and evaluation flows in minutes.</p>
+        </div>
+        <div class="panel hero__card">
+          <div class="hero__pill">Observability</div>
+          <h3>Trace every interaction</h3>
+          <p class="subtle">Built-in hooks keep your sessions debuggable with metrics and evaluation reports.</p>
+        </div>
+      </div>
+    </div>
+  </section>
+</template>
+
+<style scoped>
+.hero__content {
+  display: grid;
+  gap: 20px;
+  text-align: left;
+}
+
+h1 {
+  margin: 0;
+  font-size: clamp(32px, 5vw, 54px);
+}
+
+.hero__actions {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.hero__cards {
+  display: grid;
+  gap: 14px;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.hero__card {
+  padding: 24px;
+  border-radius: 20px;
+}
+
+.hero__pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 14px;
+  border-radius: 999px;
+  background: rgba(124, 58, 237, 0.16);
+  color: var(--accent-2);
+  font-weight: 700;
+  border: 1px solid rgba(124, 58, 237, 0.3);
+}
+</style>

--- a/docs-site/src/components/NavBar.vue
+++ b/docs-site/src/components/NavBar.vue
@@ -1,0 +1,69 @@
+<template>
+  <header class="nav">
+    <div class="container nav__inner">
+      <div class="nav__brand">RAGLight</div>
+      <nav class="nav__links">
+        <a href="#features">Features</a>
+        <a href="#architecture">Architecture</a>
+        <a href="#docs">Docs</a>
+      </nav>
+      <div class="nav__actions">
+        <a class="button secondary" href="https://github.com/anthodev/raglight" target="_blank" rel="noreferrer">
+          View on GitHub
+        </a>
+        <a class="button primary" href="#get-started">Get started</a>
+      </div>
+    </div>
+  </header>
+</template>
+
+<style scoped>
+.nav {
+  position: sticky;
+  top: 0;
+  z-index: 20;
+  backdrop-filter: blur(12px);
+  background: rgba(11, 13, 23, 0.85);
+  border-bottom: 1px solid var(--card-border);
+}
+
+.nav__inner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 18px 0;
+  gap: 14px;
+}
+
+.nav__brand {
+  font-weight: 800;
+  letter-spacing: 0.5px;
+}
+
+.nav__links {
+  display: flex;
+  gap: 24px;
+  color: var(--text-secondary);
+}
+
+.nav__links a:hover {
+  color: var(--text-primary);
+}
+
+.nav__actions {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+}
+
+@media (max-width: 900px) {
+  .nav__links {
+    display: none;
+  }
+
+  .nav__actions {
+    width: 100%;
+    justify-content: flex-end;
+  }
+}
+</style>

--- a/docs-site/src/components/SectionCard.vue
+++ b/docs-site/src/components/SectionCard.vue
@@ -1,0 +1,34 @@
+<template>
+  <div class="panel card">
+    <div class="card__tag">{{ tag }}</div>
+    <h3>{{ title }}</h3>
+    <p class="subtle">{{ description }}</p>
+  </div>
+</template>
+
+<script setup>
+defineProps({
+  title: String,
+  description: String,
+  tag: String
+})
+</script>
+
+<style scoped>
+.card {
+  padding: 22px;
+  border-radius: 18px;
+  display: grid;
+  gap: 8px;
+}
+
+.card__tag {
+  width: fit-content;
+  background: rgba(56, 189, 248, 0.12);
+  color: var(--text-primary);
+  border: 1px solid rgba(56, 189, 248, 0.3);
+  padding: 6px 10px;
+  border-radius: 10px;
+  font-weight: 700;
+}
+</style>

--- a/docs-site/src/components/Timeline.vue
+++ b/docs-site/src/components/Timeline.vue
@@ -1,0 +1,56 @@
+<template>
+  <section class="timeline" id="architecture">
+    <div class="container">
+      <div class="section__header">
+        <h2>Ship features with confidence</h2>
+        <p class="subtle">A pragmatic path from prototype to production-grade retrieval augmented experiences.</p>
+      </div>
+      <div class="timeline__steps">
+        <div v-for="(step, index) in steps" :key="step.title" class="panel step">
+          <div class="step__index">0{{ index + 1 }}</div>
+          <div>
+            <h3>{{ step.title }}</h3>
+            <p class="subtle">{{ step.detail }}</p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+</template>
+
+<script setup>
+defineProps({
+  steps: {
+    type: Array,
+    required: true
+  }
+})
+</script>
+
+<style scoped>
+.timeline__steps {
+  display: grid;
+  gap: 16px;
+}
+
+.step {
+  padding: 22px;
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 12px;
+  align-items: center;
+  border-radius: 18px;
+}
+
+.step__index {
+  width: 48px;
+  height: 48px;
+  border-radius: 12px;
+  background: rgba(124, 58, 237, 0.16);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--accent-2);
+  font-weight: 800;
+}
+</style>

--- a/docs-site/src/main.js
+++ b/docs-site/src/main.js
@@ -1,0 +1,5 @@
+import { createApp } from 'vue'
+import App from './App.vue'
+import './assets/base.css'
+
+createApp(App).mount('#app')

--- a/docs-site/vite.config.js
+++ b/docs-site/vite.config.js
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vite'
+import vue from '@vitejs/plugin-vue'
+
+export default defineConfig({
+  plugins: [vue()],
+  server: {
+    host: '0.0.0.0'
+  }
+})


### PR DESCRIPTION
## Summary
- scaffold a Vue + Vite documentation site for RAGLight with modular sections (hero, features, timeline, CTA, footer)
- add shared styling and layout components for a modern, minimal presentation

## Testing
- npm install (fails: 403 fetching registry packages)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694185b2ea388331aebe456bb5da444c)