### PR TITLE
Simplify docs site with README content

### DIFF
--- a/docs-site/index.html
+++ b/docs-site/index.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>RAGLight | Documentation</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/main.js"></script>
+  </body>
+</html>

--- a/docs-site/package.json
+++ b/docs-site/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "raglight-docs-site",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "vue": "^3.4.21"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-vue": "^5.0.0",
+    "vite": "^5.2.0"
+  }
+}

--- a/docs-site/src/App.vue
+++ b/docs-site/src/App.vue
@@ -1,0 +1,270 @@
+<template>
+  <div>
+    <NavBar />
+    <main>
+      <HeroSection />
+
+      <FeatureGrid :features="features" />
+
+      <ContentSection
+        sectionId="getting-started"
+        title="Getting started"
+        subtitle="Install the library, try the CLI, and build your first pipeline with the snippets from the README."
+      >
+        <div class="grid" style="grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));">
+          <div class="panel">
+            <h3>Install</h3>
+            <p class="subtle">Grab the package from PyPI.</p>
+            <pre><code>pip install raglight</code></pre>
+          </div>
+          <div class="panel">
+            <h3>Use the CLI</h3>
+            <p class="subtle">Launch the chat wizards without writing code.</p>
+            <pre><code>raglight chat
+raglight agentic-chat</code></pre>
+          </div>
+          <div class="panel">
+            <h3>Quick start</h3>
+            <p class="subtle">Run the minimal RAG example from the README.</p>
+            <pre><code>from raglight.rag.simple_rag_api import RAGPipeline
+from raglight.config.settings import Settings
+from raglight.config.rag_config import RAGConfig
+from raglight.config.vector_store_config import VectorStoreConfig
+
+vector_store_config = VectorStoreConfig(
+    embedding_model=Settings.DEFAULT_EMBEDDINGS_MODEL,
+    api_base=Settings.DEFAULT_OLLAMA_CLIENT,
+    provider=Settings.HUGGINGFACE,
+    database=Settings.CHROMA,
+    persist_directory='./defaultDb',
+    collection_name=Settings.DEFAULT_COLLECTION_NAME,
+)
+
+config = RAGConfig(
+    llm=Settings.DEFAULT_LLM,
+    provider=Settings.OLLAMA,
+)
+
+pipeline = RAGPipeline(config, vector_store_config)
+pipeline.build()
+response = pipeline.generate("How can I create an easy RAGPipeline using raglight framework ?")</code></pre>
+          </div>
+        </div>
+      </ContentSection>
+
+      <ContentSection
+        sectionId="docs"
+        title="Core elements"
+        subtitle="Each block of RAGLight is described in the README so you can assemble the right pipeline."
+      >
+        <div class="grid" style="grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));">
+          <SectionCard
+            v-for="card in coreElements"
+            :key="card.title"
+            :title="card.title"
+            :description="card.description"
+            :tag="card.tag"
+          />
+        </div>
+      </ContentSection>
+
+      <Timeline :steps="setupSteps" />
+
+      <ContentSection
+        sectionId="setup"
+        title="Providers and setup"
+        subtitle="Everything available in the README: requirements, environment variables, and provider options."
+      >
+        <div class="grid" style="grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));">
+          <div class="panel">
+            <h3>Requirements</h3>
+            <p class="subtle">Supported LLM services.</p>
+            <ul class="subtle list">
+              <li>Ollama</li>
+              <li>Google Gemini</li>
+              <li>LMStudio</li>
+              <li>vLLM</li>
+              <li>OpenAI API</li>
+              <li>Mistral API</li>
+            </ul>
+          </div>
+          <div class="panel">
+            <h3>Environment</h3>
+            <p class="subtle">Tune clients with environment variables.</p>
+            <ul class="subtle list">
+              <li>MISTRAL_API_KEY</li>
+              <li>OLLAMA_CLIENT_URL</li>
+              <li>LMSTUDIO_CLIENT</li>
+              <li>OPENAI_CLIENT_URL</li>
+              <li>OPENAI_API_KEY</li>
+              <li>GEMINI_API_KEY</li>
+            </ul>
+          </div>
+          <div class="panel">
+            <h3>Providers</h3>
+            <p class="subtle">Pick what you need for each layer.</p>
+            <ul class="subtle list">
+              <li>LLM: LMStudio, Ollama, Mistral, vLLM, OpenAI, Google</li>
+              <li>Embeddings: HuggingFace, Ollama, vLLM, OpenAI, Google</li>
+              <li>Vector store: Chroma</li>
+            </ul>
+          </div>
+        </div>
+      </ContentSection>
+
+      <ContentSection
+        sectionId="examples"
+        title="Examples"
+        subtitle="Direct pointers to the Python scripts in the examples folder."
+      >
+        <div class="grid" style="grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));">
+          <SectionCard
+            v-for="example in examples"
+            :key="example.title"
+            :title="example.title"
+            :description="example.description"
+            :tag="example.tag"
+          />
+        </div>
+      </ContentSection>
+
+      <CTASection />
+    </main>
+    <FooterSection />
+  </div>
+</template>
+
+<script setup>
+import NavBar from './components/NavBar.vue'
+import HeroSection from './components/HeroSection.vue'
+import FeatureGrid from './components/FeatureGrid.vue'
+import ContentSection from './components/ContentSection.vue'
+import SectionCard from './components/SectionCard.vue'
+import Timeline from './components/Timeline.vue'
+import CTASection from './components/CTASection.vue'
+import FooterSection from './components/FooterSection.vue'
+
+const features = [
+  {
+    title: 'Embeddings Model Integration',
+    description: 'Plug in preferred embedding models like HuggingFace all-MiniLM-L6-v2 for compact vector embeddings.',
+    icon: '🧠'
+  },
+  {
+    title: 'LLM Agnostic',
+    description: 'Work with multiple providers including Ollama, LMStudio, Mistral, vLLM, OpenAI, and Google Gemini.',
+    icon: '🤖'
+  },
+  {
+    title: 'RAG Pipeline',
+    description: 'Combine retrieval and generation with configurable models, prompts, and knowledge bases.',
+    icon: '🔎'
+  },
+  {
+    title: 'RAT Pipeline',
+    description: 'Add reflection loops with a reasoning LLM to improve responses when needed.',
+    icon: '🔁'
+  },
+  {
+    title: 'Agentic RAG',
+    description: 'Extend RAG with an agent that can query the vector store and follow multiple steps.',
+    icon: '🧭'
+  },
+  {
+    title: 'MCP Integration',
+    description: 'Connect external tools via MCP servers to enrich agent reasoning.',
+    icon: '🧩'
+  },
+  {
+    title: 'Flexible Document Support',
+    description: 'Ingest PDFs, text, code, and more with built-in processors and optional custom handlers.',
+    icon: '📁'
+  },
+  {
+    title: 'Extensible Architecture',
+    description: 'Swap vector stores, embeddings, or LLMs with clear configuration objects.',
+    icon: '🧱'
+  }
+]
+
+const coreElements = [
+  {
+    title: 'Knowledge Base',
+    description: 'Declare FolderSource or GitHubSource entries to ingest content when building your pipelines.',
+    tag: 'Data'
+  },
+  {
+    title: 'RAG Pipeline',
+    description: 'Set up retrieval and generation with RAGConfig and VectorStoreConfig then call build() and generate().',
+    tag: 'Retrieval'
+  },
+  {
+    title: 'Agentic RAG Pipeline',
+    description: 'Add an agent layer that can retrieve, reason over multiple steps, and respect ignore_folders.',
+    tag: 'Agent'
+  },
+  {
+    title: 'RAT Pipeline',
+    description: 'Use a reasoning model and reflection steps to enhance answers beyond standard RAG.',
+    tag: 'Reasoning'
+  },
+  {
+    title: 'Custom Builder',
+    description: 'Chain with_embeddings, with_vector_store, and with_llm to build custom pipelines.',
+    tag: 'Builder'
+  },
+  {
+    title: 'Override Processors',
+    description: 'Register processors like VlmPDFProcessor for specific file types when ingesting.',
+    tag: 'Processing'
+  }
+]
+
+const setupSteps = [
+  {
+    title: 'Prepare your sources',
+    detail: 'Collect folders or GitHub repositories you want to ingest as a knowledge base.'
+  },
+  {
+    title: 'Configure providers',
+    detail: 'Pick providers for LLM, embeddings, and vector stores; set API keys or client URLs as needed.'
+  },
+  {
+    title: 'Build and query',
+    detail: 'Call build() to ingest and use generate() to query your data with the configured pipeline.'
+  }
+]
+
+const examples = [
+  {
+    title: 'simple_rag_api_example.py',
+    description: 'Minimal RAG pipeline using RAGPipeline, VectorStoreConfig, and RAGConfig.',
+    tag: 'examples/simple_rag_api_example.py'
+  },
+  {
+    title: 'simple_agentic_rag_example.py',
+    description: 'Agentic RAG pipeline with configurable steps, prompts, and ignore_folders.',
+    tag: 'examples/simple_agentic_rag_example.py'
+  },
+  {
+    title: 'simple_rat_api_example.py',
+    description: 'Reasoning-augmented retrieval with RATPipeline and reflection loops.',
+    tag: 'examples/simple_rat_api_example.py'
+  },
+  {
+    title: 'agentic_rag_with_mcp.py',
+    description: 'Use MCP integration to add external tools to your agent.',
+    tag: 'examples/agentic_rag_with_mcp.py'
+  },
+  {
+    title: 'ingestion_example.py',
+    description: 'Ingest documents into Chroma with the builder utilities.',
+    tag: 'examples/ingestion_example.py'
+  },
+  {
+    title: 'vlm_ingestion.py',
+    description: 'Register VlmPDFProcessor for vision-language PDF ingestion.',
+    tag: 'examples/vlm_ingestion.py'
+  }
+]
+</script>

--- a/docs-site/src/assets/base.css
+++ b/docs-site/src/assets/base.css
@@ -1,0 +1,121 @@
+:root {
+  --bg-primary: #0b0d17;
+  --bg-secondary: #0f172a;
+  --bg-panel: #111827;
+  --accent: #7c3aed;
+  --accent-2: #38bdf8;
+  --text-primary: #e2e8f0;
+  --text-secondary: #94a3b8;
+  --card-border: rgba(255, 255, 255, 0.06);
+  --shadow: 0 15px 60px rgba(0, 0, 0, 0.35);
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  background: radial-gradient(circle at 20% 20%, rgba(124, 58, 237, 0.08), transparent 25%),
+    radial-gradient(circle at 80% 0%, rgba(56, 189, 248, 0.12), transparent 30%),
+    var(--bg-primary);
+  color: var(--text-primary);
+  min-height: 100%;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background: transparent;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+section {
+  padding: 96px 0;
+}
+
+.container {
+  width: min(1200px, 90vw);
+  margin: 0 auto;
+}
+
+.panel {
+  background: linear-gradient(145deg, rgba(255, 255, 255, 0.02), rgba(255, 255, 255, 0.01));
+  border: 1px solid var(--card-border);
+  border-radius: 24px;
+  box-shadow: var(--shadow);
+}
+
+.button {
+  display: inline-flex;
+  align-items: center;
+  gap: 12px;
+  padding: 14px 20px;
+  border-radius: 12px;
+  border: 1px solid transparent;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 150ms ease, box-shadow 150ms ease, border-color 150ms ease;
+}
+
+.button.primary {
+  background: linear-gradient(135deg, var(--accent), var(--accent-2));
+  color: #0b0d17;
+  box-shadow: 0 10px 35px rgba(124, 58, 237, 0.35);
+}
+
+.button.secondary {
+  background: transparent;
+  border-color: var(--card-border);
+  color: var(--text-primary);
+}
+
+.button:hover {
+  transform: translateY(-2px);
+}
+
+.grid {
+  display: grid;
+  gap: 20px;
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 12px;
+  border-radius: 999px;
+  background: rgba(124, 58, 237, 0.08);
+  color: var(--accent-2);
+  font-weight: 600;
+  border: 1px solid rgba(124, 58, 237, 0.2);
+}
+
+.subtle {
+  color: var(--text-secondary);
+}
+
+pre {
+  padding: 12px;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid var(--card-border);
+  border-radius: 12px;
+  overflow-x: auto;
+}
+
+.list {
+  padding-left: 18px;
+  display: grid;
+  gap: 6px;
+  margin: 0;
+}
+
+@media (max-width: 800px) {
+  section {
+    padding: 72px 0;
+  }
+
+  .container {
+    width: min(1000px, 92vw);
+  }
+}

--- a/docs-site/src/components/CTASection.vue
+++ b/docs-site/src/components/CTASection.vue
@@ -1,0 +1,46 @@
+<template>
+  <section id="get-started">
+    <div class="container">
+      <div class="panel cta">
+        <div>
+          <div class="badge">Try it now</div>
+          <h2>Install RAGLight and follow the README snippets.</h2>
+          <p class="subtle">
+            Use the CLI for a zero-code start or run the Python examples to build RAG, Agentic RAG, or RAT pipelines.
+          </p>
+        </div>
+        <div class="cta__actions">
+          <a class="button primary" href="https://pypi.org/project/raglight/" target="_blank" rel="noreferrer">
+            Install from PyPI
+          </a>
+          <a class="button secondary" href="https://github.com/Bessouat40/RAGLight" target="_blank" rel="noreferrer">
+            Open README
+          </a>
+        </div>
+      </div>
+    </div>
+  </section>
+</template>
+
+<style scoped>
+.cta {
+  padding: 28px;
+  display: grid;
+  gap: 18px;
+  align-items: center;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  border-radius: 20px;
+}
+
+.cta__actions {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
+h2 {
+  margin: 8px 0 0 0;
+  font-size: clamp(26px, 3vw, 32px);
+}
+</style>

--- a/docs-site/src/components/ContentSection.vue
+++ b/docs-site/src/components/ContentSection.vue
@@ -1,0 +1,43 @@
+<template>
+  <section :id="sectionId">
+    <div class="container">
+      <div class="section__header">
+        <h2>{{ title }}</h2>
+        <p class="subtle">{{ subtitle }}</p>
+      </div>
+      <div>
+        <slot />
+      </div>
+    </div>
+  </section>
+</template>
+
+<script setup>
+const props = defineProps({
+  title: {
+    type: String,
+    required: true
+  },
+  subtitle: {
+    type: String,
+    required: true
+  },
+  sectionId: {
+    type: String,
+    default: ''
+  }
+})
+</script>
+
+<style scoped>
+h2 {
+  margin: 0 0 8px 0;
+  font-size: clamp(28px, 3vw, 36px);
+}
+
+.section__header {
+  display: grid;
+  gap: 6px;
+  margin-bottom: 18px;
+}
+</style>

--- a/docs-site/src/components/FeatureGrid.vue
+++ b/docs-site/src/components/FeatureGrid.vue
@@ -1,0 +1,57 @@
+<template>
+  <section id="features">
+    <div class="container">
+      <div class="section__header">
+        <h2>Features from the README</h2>
+        <p class="subtle">Directly taken from the documented capabilities of RAGLight.</p>
+      </div>
+      <div class="grid" style="grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));">
+        <div v-for="feature in features" :key="feature.title" class="panel feature">
+          <span class="feature__icon">{{ feature.icon }}</span>
+          <h3>{{ feature.title }}</h3>
+          <p class="subtle">{{ feature.description }}</p>
+        </div>
+      </div>
+    </div>
+  </section>
+</template>
+
+<script setup>
+defineProps({
+  features: {
+    type: Array,
+    required: true
+  }
+})
+</script>
+
+<style scoped>
+h2 {
+  margin: 0 0 12px 0;
+  font-size: clamp(28px, 3vw, 36px);
+}
+
+.section__header {
+  display: grid;
+  gap: 6px;
+  margin-bottom: 24px;
+}
+
+.feature {
+  padding: 22px;
+  border-radius: 18px;
+  display: grid;
+  gap: 8px;
+}
+
+.feature__icon {
+  font-size: 24px;
+  width: 48px;
+  height: 48px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 12px;
+  background: rgba(124, 58, 237, 0.14);
+}
+</style>

--- a/docs-site/src/components/FooterSection.vue
+++ b/docs-site/src/components/FooterSection.vue
@@ -1,0 +1,50 @@
+<template>
+  <footer class="footer" id="docs">
+    <div class="container footer__content">
+      <div>
+        <div class="nav__brand">RAGLight</div>
+        <p class="subtle">Summaries taken directly from the README and examples.</p>
+      </div>
+      <div class="footer__links">
+        <a href="https://github.com/Bessouat40/RAGLight" target="_blank" rel="noreferrer">GitHub</a>
+        <a href="https://pypi.org/project/raglight/" target="_blank" rel="noreferrer">PyPI</a>
+        <a href="#getting-started">Getting started</a>
+        <a href="#setup">Setup</a>
+        <a href="#examples">Examples</a>
+      </div>
+    </div>
+  </footer>
+</template>
+
+<style scoped>
+.footer {
+  padding: 32px 0;
+  border-top: 1px solid var(--card-border);
+  background: rgba(15, 23, 42, 0.9);
+}
+
+.footer__content {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 14px;
+}
+
+.footer__links {
+  display: flex;
+  gap: 16px;
+  flex-wrap: wrap;
+  color: var(--text-secondary);
+}
+
+.footer__links a:hover {
+  color: var(--text-primary);
+}
+
+@media (max-width: 800px) {
+  .footer__content {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+}
+</style>

--- a/docs-site/src/components/HeroSection.vue
+++ b/docs-site/src/components/HeroSection.vue
@@ -1,0 +1,72 @@
+<template>
+  <section class="hero" id="top">
+    <div class="container hero__content">
+      <div class="badge">Lightweight RAG library</div>
+      <h1>RAGLight keeps retrieval-augmented workflows simple.</h1>
+      <p class="subtle">
+        Modular Python components for Retrieval-Augmented Generation: configure your providers, ingest data, and
+        generate answers with clear pipelines.
+      </p>
+      <div class="hero__actions">
+        <a class="button primary" href="#getting-started">Get started</a>
+        <a class="button secondary" href="https://github.com/Bessouat40/RAGLight" target="_blank" rel="noreferrer">
+          View README
+        </a>
+      </div>
+      <div class="hero__cards">
+        <div class="panel hero__card">
+          <div class="hero__pill">CLI</div>
+          <h3>Chat quickly</h3>
+          <p class="subtle">Run <code>raglight chat</code> or <code>raglight agentic-chat</code> to test without writing code.</p>
+        </div>
+        <div class="panel hero__card">
+          <div class="hero__pill">Pipelines</div>
+          <h3>Pick your flow</h3>
+          <p class="subtle">Use RAG, Agentic RAG, or RAT pipelines described in the README.</p>
+        </div>
+      </div>
+    </div>
+  </section>
+</template>
+
+<style scoped>
+.hero__content {
+  display: grid;
+  gap: 20px;
+  text-align: left;
+}
+
+h1 {
+  margin: 0;
+  font-size: clamp(32px, 5vw, 54px);
+}
+
+.hero__actions {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.hero__cards {
+  display: grid;
+  gap: 14px;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.hero__card {
+  padding: 24px;
+  border-radius: 20px;
+}
+
+.hero__pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 14px;
+  border-radius: 999px;
+  background: rgba(124, 58, 237, 0.16);
+  color: var(--accent-2);
+  font-weight: 700;
+  border: 1px solid rgba(124, 58, 237, 0.3);
+}
+</style>

--- a/docs-site/src/components/NavBar.vue
+++ b/docs-site/src/components/NavBar.vue
@@ -1,0 +1,72 @@
+<template>
+  <header class="nav">
+    <div class="container nav__inner">
+      <a class="nav__brand" href="#top">RAGLight</a>
+      <nav class="nav__links">
+        <a href="#getting-started">Getting started</a>
+        <a href="#docs">Docs</a>
+        <a href="#setup">Setup</a>
+        <a href="#examples">Examples</a>
+      </nav>
+      <div class="nav__actions">
+        <a class="button secondary" href="https://github.com/Bessouat40/RAGLight" target="_blank" rel="noreferrer">
+          GitHub
+        </a>
+        <a class="button primary" href="#getting-started">Get started</a>
+      </div>
+    </div>
+  </header>
+</template>
+
+<style scoped>
+.nav {
+  position: sticky;
+  top: 0;
+  z-index: 20;
+  backdrop-filter: blur(12px);
+  background: rgba(11, 13, 23, 0.85);
+  border-bottom: 1px solid var(--card-border);
+}
+
+.nav__inner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 18px 0;
+  gap: 14px;
+}
+
+.nav__brand {
+  font-weight: 800;
+  letter-spacing: 0.5px;
+  color: var(--text-primary);
+  text-decoration: none;
+}
+
+.nav__links {
+  display: flex;
+  gap: 24px;
+  color: var(--text-secondary);
+}
+
+.nav__links a:hover {
+  color: var(--text-primary);
+}
+
+.nav__actions {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+}
+
+@media (max-width: 900px) {
+  .nav__links {
+    display: none;
+  }
+
+  .nav__actions {
+    width: 100%;
+    justify-content: flex-end;
+  }
+}
+</style>

--- a/docs-site/src/components/SectionCard.vue
+++ b/docs-site/src/components/SectionCard.vue
@@ -1,0 +1,34 @@
+<template>
+  <div class="panel card">
+    <div class="card__tag">{{ tag }}</div>
+    <h3>{{ title }}</h3>
+    <p class="subtle">{{ description }}</p>
+  </div>
+</template>
+
+<script setup>
+defineProps({
+  title: String,
+  description: String,
+  tag: String
+})
+</script>
+
+<style scoped>
+.card {
+  padding: 22px;
+  border-radius: 18px;
+  display: grid;
+  gap: 8px;
+}
+
+.card__tag {
+  width: fit-content;
+  background: rgba(56, 189, 248, 0.12);
+  color: var(--text-primary);
+  border: 1px solid rgba(56, 189, 248, 0.3);
+  padding: 6px 10px;
+  border-radius: 10px;
+  font-weight: 700;
+}
+</style>

--- a/docs-site/src/components/Timeline.vue
+++ b/docs-site/src/components/Timeline.vue
@@ -1,0 +1,56 @@
+<template>
+  <section class="timeline" id="architecture">
+    <div class="container">
+      <div class="section__header">
+        <h2>Setup flow</h2>
+        <p class="subtle">Follow the same order shown in the README examples.</p>
+      </div>
+      <div class="timeline__steps">
+        <div v-for="(step, index) in steps" :key="step.title" class="panel step">
+          <div class="step__index">0{{ index + 1 }}</div>
+          <div>
+            <h3>{{ step.title }}</h3>
+            <p class="subtle">{{ step.detail }}</p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+</template>
+
+<script setup>
+defineProps({
+  steps: {
+    type: Array,
+    required: true
+  }
+})
+</script>
+
+<style scoped>
+.timeline__steps {
+  display: grid;
+  gap: 16px;
+}
+
+.step {
+  padding: 22px;
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 12px;
+  align-items: center;
+  border-radius: 18px;
+}
+
+.step__index {
+  width: 48px;
+  height: 48px;
+  border-radius: 12px;
+  background: rgba(124, 58, 237, 0.16);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--accent-2);
+  font-weight: 800;
+}
+</style>

--- a/docs-site/src/main.js
+++ b/docs-site/src/main.js
@@ -1,0 +1,5 @@
+import { createApp } from 'vue'
+import App from './App.vue'
+import './assets/base.css'
+
+createApp(App).mount('#app')

--- a/docs-site/vite.config.js
+++ b/docs-site/vite.config.js
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vite'
+import vue from '@vitejs/plugin-vue'
+
+export default defineConfig({
+  plugins: [vue()],
+  server: {
+    host: '0.0.0.0'
+  }
+})


### PR DESCRIPTION
## Summary
- align the Vue docs site content with README information across hero, features, and section links
- add getting started, core elements, setup, and examples sections based strictly on README and examples folder
- improve base styles for code snippets and lists used in the updated content

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694185b2ea388331aebe456bb5da444c)