### PR TITLE
Add frontend documentation site

### DIFF
--- a/README.md
+++ b/README.md
@@ -573,3 +573,19 @@ docker run --add-host=host.docker.internal:host-gateway docker-raglight
 ```
 
 We use `--add-host` flag to allow Ollama call.
+
+## Documentation site (frontend)
+
+A Vue 3 + Vite site in `frontend/` renders the README and examples as developer-focused docs.
+
+### Build locally
+```bash
+cd frontend
+npm install
+npm run build
+```
+
+### Deploy to GitHub Pages
+- Ensure `base` in `frontend/vite.config.ts` matches the repository name (default is `/RAGLight/`).
+- Run `npm run build` to generate the `dist/` folder.
+- Publish the `dist/` folder to GitHub Pages (for example by pushing it to a `gh-pages` branch or configuring GitHub Pages to serve from that folder).

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>RAGLight Documentation</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "raglight-docs",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "vue": "^3.4.0",
+    "vue-router": "^4.3.0"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-vue": "^5.0.0",
+    "typescript": "^5.3.0",
+    "vite": "^5.0.0"
+  }
+}

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1,0 +1,7 @@
+<template>
+  <AppLayout />
+</template>
+
+<script setup lang="ts">
+import AppLayout from './layouts/AppLayout.vue';
+</script>

--- a/frontend/src/components/CodeBlock.vue
+++ b/frontend/src/components/CodeBlock.vue
@@ -1,0 +1,14 @@
+<template>
+  <pre class="code-block"><code><slot /></code></pre>
+</template>
+
+<style scoped>
+.code-block {
+  background: var(--code-bg);
+  border: 1px solid var(--border-color);
+  padding: 12px;
+  border-radius: 8px;
+  overflow-x: auto;
+  white-space: pre-wrap;
+}
+</style>

--- a/frontend/src/components/Navbar.vue
+++ b/frontend/src/components/Navbar.vue
@@ -1,0 +1,51 @@
+<template>
+  <header class="navbar">
+    <div class="brand">
+      <router-link to="/">RAGLight Docs</router-link>
+    </div>
+    <nav class="nav-links">
+      <router-link to="/getting-started">Getting Started</router-link>
+      <router-link to="/docs">Documentation</router-link>
+      <router-link to="/setup">Setup</router-link>
+      <router-link to="/examples">Examples</router-link>
+      <ThemeToggle />
+    </nav>
+  </header>
+</template>
+
+<script setup lang="ts">
+import ThemeToggle from './ThemeToggle.vue';
+</script>
+
+<style scoped>
+.navbar {
+  grid-column: 1 / -1;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 16px 24px;
+  border-bottom: 1px solid var(--border-color);
+  background: var(--bg-color);
+}
+
+.brand a {
+  font-weight: 700;
+  font-size: 18px;
+}
+
+.nav-links {
+  display: flex;
+  gap: 16px;
+  align-items: center;
+}
+
+.nav-links a {
+  padding: 6px 10px;
+  border-radius: 6px;
+  border: 1px solid transparent;
+}
+
+.nav-links a.router-link-active {
+  border-color: var(--border-color);
+}
+</style>

--- a/frontend/src/components/Sidebar.vue
+++ b/frontend/src/components/Sidebar.vue
@@ -1,0 +1,42 @@
+<template>
+  <aside class="sidebar">
+    <div class="sidebar-section">
+      <h4>Overview</h4>
+      <router-link to="/">Home</router-link>
+    </div>
+    <div class="sidebar-section">
+      <h4>Guides</h4>
+      <router-link to="/getting-started">Getting Started</router-link>
+      <router-link to="/docs">Documentation</router-link>
+      <router-link to="/setup">Setup & Configuration</router-link>
+    </div>
+    <div class="sidebar-section">
+      <h4>Examples</h4>
+      <router-link to="/examples">Examples</router-link>
+    </div>
+  </aside>
+</template>
+
+<style scoped>
+.sidebar {
+  padding: 24px;
+  border-right: 1px solid var(--border-color);
+  min-height: calc(100vh - 64px);
+  background: var(--bg-color);
+}
+
+.sidebar-section {
+  margin-bottom: 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.sidebar h4 {
+  margin: 0;
+  font-size: 14px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--text-color);
+}
+</style>

--- a/frontend/src/components/ThemeToggle.vue
+++ b/frontend/src/components/ThemeToggle.vue
@@ -1,0 +1,22 @@
+<template>
+  <button class="toggle" type="button" @click="toggleTheme">
+    {{ theme === 'light' ? 'Dark mode' : 'Light mode' }}
+  </button>
+</template>
+
+<script setup lang="ts">
+import { useTheme } from '../composables/useTheme';
+
+const { theme, toggleTheme } = useTheme();
+</script>
+
+<style scoped>
+.toggle {
+  border: 1px solid var(--border-color);
+  background: var(--bg-color);
+  color: var(--text-color);
+  padding: 6px 10px;
+  border-radius: 6px;
+  cursor: pointer;
+}
+</style>

--- a/frontend/src/composables/useTheme.ts
+++ b/frontend/src/composables/useTheme.ts
@@ -1,0 +1,32 @@
+import { onMounted, ref } from 'vue';
+
+const STORAGE_KEY = 'raglight-theme';
+
+type Theme = 'light' | 'dark';
+
+export function useTheme() {
+  const theme = ref<Theme>('light');
+
+  const applyTheme = (value: Theme) => {
+    theme.value = value;
+    document.documentElement.setAttribute('data-theme', value);
+    localStorage.setItem(STORAGE_KEY, value);
+  };
+
+  const toggleTheme = () => {
+    applyTheme(theme.value === 'light' ? 'dark' : 'light');
+  };
+
+  onMounted(() => {
+    const stored = localStorage.getItem(STORAGE_KEY) as Theme | null;
+    if (stored === 'light' || stored === 'dark') {
+      applyTheme(stored);
+      return;
+    }
+
+    const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+    applyTheme(prefersDark ? 'dark' : 'light');
+  });
+
+  return { theme, toggleTheme };
+}

--- a/frontend/src/layouts/AppLayout.vue
+++ b/frontend/src/layouts/AppLayout.vue
@@ -1,0 +1,14 @@
+<template>
+  <div class="layout">
+    <Navbar />
+    <Sidebar />
+    <main class="main-content">
+      <router-view />
+    </main>
+  </div>
+</template>
+
+<script setup lang="ts">
+import Navbar from '../components/Navbar.vue';
+import Sidebar from '../components/Sidebar.vue';
+</script>

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -1,0 +1,6 @@
+import { createApp } from 'vue';
+import App from './App.vue';
+import router from './router';
+import './styles/base.css';
+
+createApp(App).use(router).mount('#app');

--- a/frontend/src/pages/Docs.vue
+++ b/frontend/src/pages/Docs.vue
@@ -1,0 +1,92 @@
+<template>
+  <section class="page-section">
+    <h1>Documentation</h1>
+  </section>
+
+  <section class="page-section">
+    <h2>What is RAGLight</h2>
+    <p>RAGLight is a lightweight and modular Python library for implementing Retrieval-Augmented Generation (RAG). It enhances LLMs by combining document retrieval with natural language inference.</p>
+  </section>
+
+  <section class="page-section">
+    <h2>Core concepts</h2>
+    <ul>
+      <li><strong>Embeddings Model Integration</strong>: Plug in embedding models for compact and efficient vector embeddings.</li>
+      <li><strong>LLM Agnostic</strong>: Integrates with different LLM providers.</li>
+      <li><strong>RAG, RAT, and Agentic RAG pipelines</strong> unify retrieval and generation, with options for reflection loops and agents.</li>
+      <li><strong>MCP Integration</strong> adds tool capabilities via MCP servers.</li>
+      <li><strong>Flexible Document Support</strong> for PDF, TXT, DOCX, Python, Javascript, and more.</li>
+      <li><strong>Extensible Architecture</strong> to swap vector stores, embeddings, or LLMs.</li>
+    </ul>
+  </section>
+
+  <section class="page-section">
+    <h2>Knowledge</h2>
+    <p>Define knowledge bases to ingest data into your vector store.</p>
+    <CodeBlock>
+from raglight import RAGPipeline
+pipeline = RAGPipeline(knowledge_base=[
+    FolderSource(path="<path to your folder with pdf>/knowledge_base"),
+    GitHubSource(url="https://github.com/Bessouat40/RAGLight")
+    ],
+    model_name="llama3",
+    provider=Settings.OLLAMA,
+    k=5)
+
+pipeline.build()
+    </CodeBlock>
+  </section>
+
+  <section class="page-section">
+    <h2>Readers</h2>
+    <p>The README focuses on retrieval pipelines; reader-specific APIs are not detailed.</p>
+  </section>
+
+  <section class="page-section">
+    <h2>Embedders</h2>
+    <p>Use embedding providers such as Huggingface, Ollama, vLLM, OpenAI, or Google Gemini.</p>
+    <CodeBlock>
+vector_store_config = VectorStoreConfig(
+    embedding_model = Settings.DEFAULT_EMBEDDINGS_MODEL,
+    api_base = Settings.DEFAULT_OLLAMA_CLIENT,
+    provider=Settings.HUGGINGFACE,
+    database=Settings.CHROMA,
+    persist_directory = './defaultDb',
+    collection_name = Settings.DEFAULT_COLLECTION_NAME
+)
+    </CodeBlock>
+  </section>
+
+  <section class="page-section">
+    <h2>Vector stores</h2>
+    <p>Chroma is available as the vector store option.</p>
+  </section>
+
+  <section class="page-section">
+    <h2>Models</h2>
+    <p>Providers include LMStudio, Ollama, Mistral API, vLLM, OpenAI, and Google Gemini.</p>
+  </section>
+
+  <section class="page-section">
+    <h2>Agents</h2>
+    <p>Agentic RAG adds an agent that can retrieve data from your vector store with configurable provider, model, k, max_steps, API settings, and ignore folders.</p>
+    <CodeBlock>
+config = AgenticRAGConfig(
+            provider = Settings.MISTRAL,
+            model = "mistral-large-2411",
+            k = 10,
+            system_prompt = Settings.DEFAULT_AGENT_PROMPT,
+            max_steps = 4,
+            api_key = Settings.MISTRAL_API_KEY,
+            ignore_folders = custom_ignore_folders,
+        )
+
+agenticRag = AgenticRAGPipeline(config, vector_store_config)
+agenticRag.build()
+    </CodeBlock>
+  </section>
+</template>
+
+<script setup lang="ts">
+import CodeBlock from '../components/CodeBlock.vue';
+</script>

--- a/frontend/src/pages/Examples.vue
+++ b/frontend/src/pages/Examples.vue
@@ -1,0 +1,408 @@
+<template>
+  <section class="page-section">
+    <h1>Examples</h1>
+    <p>Examples sourced from the repository <code>examples/</code> directory.</p>
+  </section>
+
+  <section v-for="example in examples" :key="example.name" class="page-section">
+    <h2>{{ example.name }}</h2>
+    <p>{{ example.description }}</p>
+    <CodeBlock>{{ example.code }}</CodeBlock>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue';
+import CodeBlock from '../components/CodeBlock.vue';
+
+const examples = computed(() => [
+  {
+    name: 'simple_rag_api_example.py',
+    description: 'RAG pipeline using the simple API.',
+    code: `from raglight.rag.simple_rag_api import RAGPipeline
+from raglight.models.data_source_model import FolderSource, GitHubSource
+from raglight.config.settings import Settings
+from raglight.config.rag_config import RAGConfig
+from raglight.config.vector_store_config import VectorStoreConfig
+
+Settings.setup_logging()
+
+knowledge_base=[
+    FolderSource(path="<path to your folder with pdf>/knowledge_base"),
+    GitHubSource(url="https://github.com/Bessouat40/RAGLight")
+    ]
+
+vector_store_config = VectorStoreConfig(
+    embedding_model = Settings.DEFAULT_EMBEDDINGS_MODEL,
+    provider=Settings.HUGGINGFACE,
+    # api_base = ... # If you have a custom client URL
+    database=Settings.CHROMA,
+    persist_directory = './defaultDb',
+    collection_name = Settings.DEFAULT_COLLECTION_NAME
+)
+
+config = RAGConfig(
+        llm = Settings.DEFAULT_LLM,
+        provider = Settings.OLLAMA,
+        # api_base = ... # If you have a custom client URL
+        # k = Settings.DEFAULT_K,
+        # cross_encoder_model = Settings.DEFAULT_CROSS_ENCODER_MODEL,
+        # system_prompt = Settings.DEFAULT_SYSTEM_PROMPT,
+        # knowledge_base = knowledge_base
+    )
+
+pipeline = RAGPipeline(config, vector_store_config)
+
+pipeline.build()
+
+response = pipeline.generate("How can I create an easy RAGPipeline using raglight framework ? Give me python implementation")
+print(response)`
+  },
+  {
+    name: 'simple_agentic_rag_example.py',
+    description: 'Agentic RAG pipeline with custom ignore folders.',
+    code: `from raglight.config.settings import Settings
+from raglight.rag.simple_agentic_rag_api import AgenticRAGPipeline
+from raglight.config.agentic_rag_config import AgenticRAGConfig
+from raglight.config.vector_store_config import VectorStoreConfig
+from raglight.config.settings import Settings
+from raglight.models.data_source_model import FolderSource
+from raglight.models.data_source_model import GitHubSource
+from dotenv import load_dotenv
+
+load_dotenv()
+Settings.setup_logging()
+
+knowledge_base=[
+    # FolderSource(path="<path to your folder with pdf>/knowledge_base"),
+    GitHubSource(url="https://github.com/Bessouat40/RAGLight", branch="main"),
+    ]
+
+persist_directory = './defaultDb'
+model_embeddings = Settings.DEFAULT_EMBEDDINGS_MODEL
+collection_name = Settings.DEFAULT_COLLECTION_NAME
+
+vector_store_config = VectorStoreConfig(
+    embedding_model = model_embeddings,
+    # api_base = ... # If you have a custom client URL
+    database=Settings.CHROMA,
+    # host='localhost', If you want to use a remote ChromaDB
+    # port='8000', If you want to use a remote ChromaDB
+    persist_directory = persist_directory, # If you want to use a local ChromaDB
+    provider = Settings.OLLAMA,
+    collection_name = collection_name
+)
+
+# Custom ignore folders - you can override the default list
+custom_ignore_folders = [
+    ".venv",
+    "venv",
+    "node_modules",
+    "__pycache__",
+    ".git",
+    "build",
+    "dist",
+    "my_custom_folder_to_ignore"  # Add your custom folders here
+]
+
+config = AgenticRAGConfig(
+            provider = Settings.MISTRAL,
+            model = "mistral-large-2411",
+            k = 10,
+            system_prompt = Settings.DEFAULT_AGENT_PROMPT,
+            # mcp_config=[
+            #     {"url": "http://127.0.0.1:8001/sse"}
+            # ],
+            # api_base = ... # If you have a custom client URL
+            max_steps = 5,
+            api_key = Settings.MISTRAL_API_KEY, # os.environ.get('MISTRAL_API_KEY')
+            ignore_folders = custom_ignore_folders,  # Use custom ignore folders
+            # num_ctx = ... # Max context length
+            # verbosity_level = ... # Default = 2
+            knowledge_base = knowledge_base
+        )
+
+agenticRag = AgenticRAGPipeline(config, vector_store_config)
+
+agenticRag.build()
+
+response = agenticRag.generate("Please implement Agentic RAG for me.")
+
+print('response : ', response)`
+  },
+  {
+    name: 'simple_rat_api_example.py',
+    description: 'RAT pipeline with reasoning LLM settings.',
+    code: `from raglight.rat.simple_rat_api import RATPipeline
+from raglight.models.data_source_model import FolderSource, GitHubSource
+from raglight.config.settings import Settings
+from raglight.config.rat_config import RATConfig
+from raglight.config.vector_store_config import VectorStoreConfig
+
+Settings.setup_logging()
+
+knowledge_base=[
+    FolderSource(path="<path to the folder you want to ingest into your knowledge base>"),
+    GitHubSource(url="https://github.com/Bessouat40/RAGLight")
+    ]
+
+vector_store_config = VectorStoreConfig(
+    embedding_model = Settings.DEFAULT_EMBEDDINGS_MODEL,
+    # api_base = ... # If you have a custom client URL
+    provider=Settings.HUGGINGFACE,
+    database=Settings.CHROMA,
+    persist_directory = './defaultDb',
+    collection_name = Settings.DEFAULT_COLLECTION_NAME
+)
+
+config = RATConfig(
+        cross_encoder_model = Settings.DEFAULT_CROSS_ENCODER_MODEL,
+        # api_base = ... # If you have a custom client URL
+        llm = "llama3.2:3b",
+        k = Settings.DEFAULT_K,
+        provider = Settings.OLLAMA,
+        system_prompt = Settings.DEFAULT_SYSTEM_PROMPT,
+        reasoning_llm = Settings.DEFAULT_REASONING_LLM,
+        reflection = 3
+        # knowledge_base = knowledge_base,
+    )
+
+pipeline = RATPipeline(config, vector_store_config)
+
+# This will ingest data from the knowledge base. Not mandatory if you have already ingested the data.
+pipeline.build()
+
+response = pipeline.generate("How can I create an easy RAGPipeline using raglight framework ? Give me the the easier python implementation")
+print(response)`
+  },
+  {
+    name: 'agentic_rag_with_mcp.py',
+    description: 'Agentic RAG configured with an MCP server.',
+    code: `from raglight.config.settings import Settings
+from raglight.rag.simple_agentic_rag_api import AgenticRAGPipeline
+from raglight.config.agentic_rag_config import AgenticRAGConfig
+from raglight.config.vector_store_config import VectorStoreConfig
+from raglight.config.settings import Settings
+from raglight.models.data_source_model import FolderSource
+from raglight.models.data_source_model import GitHubSource
+from dotenv import load_dotenv
+
+load_dotenv()
+Settings.setup_logging()
+
+knowledge_base=[
+    FolderSource(path="<path to your folder with pdf>/knowledge_base"),
+    GitHubSource(url="https://github.com/Bessouat40/RAGLight")
+    ]
+
+persist_directory = './defaultDb'
+model_embeddings = Settings.DEFAULT_EMBEDDINGS_MODEL
+collection_name = Settings.DEFAULT_COLLECTION_NAME
+
+vector_store_config = VectorStoreConfig(
+    embedding_model = model_embeddings,
+    # api_base = ... # If you have a custom client URL for your embeddings provider
+    database=Settings.CHROMA,
+    persist_directory = persist_directory,
+    provider = Settings.HUGGINGFACE,
+    collection_name = collection_name
+)
+
+config = AgenticRAGConfig(
+            provider = Settings.OPENAI,
+            model = "gpt-4o",
+            k = 10,
+            system_prompt = Settings.DEFAULT_AGENT_PROMPT,
+            knowledge_base = knowledge_base,
+            mcp_config=[
+                {"url": "http://127.0.0.1:8001/sse"}
+            ],
+            max_steps = 2,
+            api_key = Settings.OPENAI_API_KEY, # os.environ.get('OPENAI_API_KEY')
+            ignore_folders = Settings.DEFAULT_IGNORE_FOLDERS,
+            # api_base = ... # If you have a custom client URL
+        )
+
+agenticRag = AgenticRAGPipeline(config, vector_store_config)
+
+agenticRag.build()
+
+response = agenticRag.generate("Please implement AgenticRAGPipeline for me using RAGLight framework.")
+
+print('response : ', response)`
+  },
+  {
+    name: 'ingestion_example.py',
+    description: 'Ingest documents into the vector store using the builder.',
+    code: `from raglight.rag.builder import Builder
+from raglight.config.settings import Settings
+from dotenv import load_dotenv
+import os
+
+load_dotenv()
+Settings.setup_logging()
+
+persist_directory = './defaultDb'
+model_embeddings = Settings.DEFAULT_EMBEDDINGS_MODEL
+collection_name = Settings.DEFAULT_COLLECTION_NAME
+data_path = os.environ.get('DATA_PATH')
+
+vector_store = Builder() \
+.with_embeddings(Settings.HUGGINGFACE, model_name=model_embeddings) \
+.with_vector_store(Settings.CHROMA, persist_directory=persist_directory, collection_name=collection_name) \
+.build_vector_store()
+
+vector_store.ingest(data_path=data_path)`
+  },
+  {
+    name: 'rag_example.py',
+    description: 'RAG pipeline built with the Builder helper.',
+    code: `from raglight.rag.builder import Builder
+from raglight.config.settings import Settings
+from dotenv import load_dotenv
+
+load_dotenv()
+Settings.setup_logging()
+
+persist_directory = './defaultDb'
+model_embeddings = Settings.DEFAULT_EMBEDDINGS_MODEL
+model_name = 'gemma3:4b'
+system_prompt_directory = Settings.DEFAULT_SYSTEM_PROMPT
+collection_name = Settings.DEFAULT_COLLECTION_NAME
+
+rag = Builder() \
+    .with_embeddings(Settings.HUGGINGFACE, model_name=model_embeddings) \
+    .with_vector_store(Settings.CHROMA, persist_directory=persist_directory, collection_name=collection_name) \
+    .with_llm(Settings.OLLAMA, model_name=model_name, system_prompt=system_prompt_directory) \
+    .build_rag(k = 5)
+
+rag.vector_store.ingest(
+                    data_path='../src/',
+                    # ignore_folders=ignore_folders
+                )
+response = rag.generate("How can I use RAGLight to build a RAG Pipeline ?")
+print(response)`
+  },
+  {
+    name: 'discussion_example.py',
+    description: 'Chat loop using an LLM built with the Builder.',
+    code: `from raglight.rag.builder import Builder
+from raglight.config.settings import Settings
+from dotenv import load_dotenv
+
+load_dotenv()
+Settings.setup_logging()
+
+model_name = 'llama3.2:3b'
+system_prompt = Settings.DEFAULT_SYSTEM_PROMPT
+
+llmOllama = Builder() \
+.with_llm(Settings.OLLAMA, model_name=model_name, system_prompt=system_prompt) \
+.build_llm()
+
+# llmLMStudio = Builder() \
+# .with_llm(Settings.LMStudio, model_name=model_name, system_prompt_file=system_prompt_directory) \
+# .build_llm()
+
+# llmLMStudio = Builder() \
+# .with_llm(Settings.MISTRAL, model_name=model_name, system_prompt_file=system_prompt_directory) \
+# .build_llm()
+
+def chat():
+    query = input(">>> ")
+    if query == "quit" or query == "bye" :
+        print('🤖 : See you soon 👋')
+        return
+    response = llmOllama.generate({"question": query})
+    # response = llmLMStudio.generate({"question": query})
+    print('🤖 : ', response)
+    return chat()
+
+chat()`
+  },
+  {
+    name: 'vlm_ingestion.py',
+    description: 'Vector store ingestion using a vision-language PDF processor.',
+    code: `from raglight.document_processing.vlm_pdf_processor import VlmPDFProcessor
+from raglight.llm.mistral_model import MistralModel
+from raglight.rag.builder import Builder
+from raglight.config.settings import Settings
+
+from dotenv import load_dotenv
+
+load_dotenv()
+Settings.setup_logging()
+
+persist_directory = "./defaultDb"
+model_embeddings = "nomic-embed-text:137m-v1.5-fp16"
+collection_name = Settings.DEFAULT_COLLECTION_NAME
+data_path = "" # Path to your data
+model_name = "mistral-large-2512"
+
+vlm = MistralModel(
+    model_name=model_name,
+    system_prompt="You are a technical documentation visual assistant.",
+)
+
+custom_processors = {
+    "pdf": VlmPDFProcessor(vlm),           # override default PDFProcessor
+}
+
+rag = Builder() \
+.with_embeddings(Settings.OLLAMA, model_name=model_embeddings) \
+.with_vector_store(Settings.CHROMA,
+                   persist_directory=persist_directory,
+                   collection_name=collection_name,
+                   custom_processors=custom_processors) \
+.with_llm(Settings.MISTRAL, model_name=model_name, system_prompt="Please respond to user answer") \
+.build_rag(k = 15)
+
+rag.vector_store.ingest(data_path=data_path)
+
+response = rag.generate("Please explain PID functionment")
+print(response)`
+  },
+  {
+    name: 'gemini_example_uses.py',
+    description: 'RAG pipeline configured for Google Gemini.',
+    code: `from raglight.rag.simple_rag_api import RAGPipeline
+from raglight.models.data_source_model import FolderSource, GitHubSource
+from raglight.config.settings import Settings
+from raglight.config.rag_config import RAGConfig
+from raglight.config.vector_store_config import VectorStoreConfig
+
+Settings.setup_logging()
+
+knowledge_base=[
+    # FolderSource(path="data/knowledge_base"),
+    GitHubSource(url="https://github.com/Bessouat40/RAGLight")
+    ]
+
+vector_store_config = VectorStoreConfig(
+    embedding_model = Settings.GEMINI_EMBEDDING_MODEL,
+    provider=Settings.GOOGLE_GEMINI,
+    database=Settings.CHROMA,
+    persist_directory = './defaultDb',
+    collection_name = Settings.DEFAULT_COLLECTION_NAME
+)
+
+config = RAGConfig(
+        api_base = Settings.DEFAULT_GOOGLE_CLIENT,
+        llm = Settings.GEMINI_LLM_MODEL,
+        provider = Settings.GOOGLE_GEMINI,
+        # stream = True,
+        # k = Settings.DEFAULT_K,
+        # cross_encoder_model = Settings.DEFAULT_CROSS_ENCODER_MODEL,
+        # system_prompt = Settings.DEFAULT_SYSTEM_PROMPT,
+        knowledge_base = knowledge_base
+    )
+
+pipeline = RAGPipeline(config, vector_store_config)
+
+pipeline.build()
+
+response = pipeline.generate("How can I create an easy RAGPipeline using raglight framework ? Give me python implementation")
+print(response)`
+  }
+]);
+</script>

--- a/frontend/src/pages/GettingStarted.vue
+++ b/frontend/src/pages/GettingStarted.vue
@@ -1,0 +1,62 @@
+<template>
+  <section class="page-section">
+    <h1>Getting Started</h1>
+    <p>Follow the steps from the README to install and run the framework.</p>
+  </section>
+
+  <section class="page-section">
+    <h2>Installation</h2>
+    <CodeBlock>pip install raglight</CodeBlock>
+  </section>
+
+  <section class="page-section">
+    <h2>Chat with your documents</h2>
+    <p>Use the CLI wizard to ingest documents and start chatting without writing code.</p>
+    <CodeBlock>raglight chat</CodeBlock>
+    <p>Launch the Agentic RAG wizard with:</p>
+    <CodeBlock>raglight agentic-chat</CodeBlock>
+  </section>
+
+  <section class="page-section">
+    <h2>Minimal RAG setup</h2>
+    <p>Quickly configure a Retrieval-Augmented Generation pipeline.</p>
+    <CodeBlock>
+from raglight.rag.simple_rag_api import RAGPipeline
+from raglight.models.data_source_model import FolderSource, GitHubSource
+from raglight.config.settings import Settings
+from raglight.config.rag_config import RAGConfig
+from raglight.config.vector_store_config import VectorStoreConfig
+
+Settings.setup_logging()
+
+knowledge_base=[
+    FolderSource(path="&lt;path to your folder with pdf&gt;/knowledge_base"),
+    GitHubSource(url="https://github.com/Bessouat40/RAGLight")
+    ]
+
+vector_store_config = VectorStoreConfig(
+    embedding_model = Settings.DEFAULT_EMBEDDINGS_MODEL,
+    provider=Settings.HUGGINGFACE,
+    database=Settings.CHROMA,
+    persist_directory = './defaultDb',
+    collection_name = Settings.DEFAULT_COLLECTION_NAME
+)
+
+config = RAGConfig(
+        llm = Settings.DEFAULT_LLM,
+        provider = Settings.OLLAMA,
+    )
+
+pipeline = RAGPipeline(config, vector_store_config)
+
+pipeline.build()
+
+response = pipeline.generate("How can I create an easy RAGPipeline using raglight framework ? Give me python implementation")
+print(response)
+    </CodeBlock>
+  </section>
+</template>
+
+<script setup lang="ts">
+import CodeBlock from '../components/CodeBlock.vue';
+</script>

--- a/frontend/src/pages/Home.vue
+++ b/frontend/src/pages/Home.vue
@@ -1,0 +1,7 @@
+<template>
+  <section class="page-section">
+    <h1>RAGLight</h1>
+    <p><strong>RAGLight</strong> is a lightweight and modular Python library for implementing Retrieval-Augmented Generation (RAG). It enhances the capabilities of Large Language Models (LLMs) by combining document retrieval with natural language inference.</p>
+    <p>Designed for simplicity and flexibility, RAGLight provides modular components to easily integrate various LLMs, embeddings, and vector stores, making it an ideal tool for building context-aware AI solutions.</p>
+  </section>
+</template>

--- a/frontend/src/pages/Setup.vue
+++ b/frontend/src/pages/Setup.vue
@@ -1,0 +1,110 @@
+<template>
+  <section class="page-section">
+    <h1>Setup & Configuration</h1>
+    <p>Options available directly from the README.</p>
+  </section>
+
+  <section class="page-section">
+    <h2>Vector store</h2>
+    <ul>
+      <li>Chroma (Settings.CHROMA)</li>
+    </ul>
+  </section>
+
+  <section class="page-section">
+    <h2>Embedding providers</h2>
+    <ul>
+      <li>Huggingface (Settings.HUGGINGFACE)</li>
+      <li>Ollama (Settings.OLLAMA)</li>
+      <li>vLLM (Settings.VLLM)</li>
+      <li>OpenAI (Settings.OPENAI)</li>
+      <li>Google Gemini (Settings.GOOGLE_GEMINI)</li>
+    </ul>
+  </section>
+
+  <section class="page-section">
+    <h2>LLM providers</h2>
+    <ul>
+      <li>LMStudio (Settings.LMSTUDIO)</li>
+      <li>Ollama (Settings.OLLAMA)</li>
+      <li>Mistral API (Settings.MISTRAL)</li>
+      <li>vLLM (Settings.VLLM)</li>
+      <li>OpenAI (Settings.OPENAI)</li>
+      <li>Google Gemini (Settings.GOOGLE_GEMINI)</li>
+    </ul>
+  </section>
+
+  <section class="page-section">
+    <h2>Environment variables</h2>
+    <ul>
+      <li>MISTRAL_API_KEY</li>
+      <li>OLLAMA_CLIENT_URL</li>
+      <li>LMSTUDIO_CLIENT</li>
+      <li>OPENAI_CLIENT_URL</li>
+      <li>OPENAI_API_KEY</li>
+      <li>GEMINI_API_KEY</li>
+    </ul>
+  </section>
+
+  <section class="page-section">
+    <h2>Configuration examples</h2>
+    <h3>Vector store configuration</h3>
+    <CodeBlock>
+vector_store_config = VectorStoreConfig(
+    embedding_model = Settings.DEFAULT_EMBEDDINGS_MODEL,
+    api_base = Settings.DEFAULT_OLLAMA_CLIENT,
+    provider=Settings.HUGGINGFACE,
+    database=Settings.CHROMA,
+    persist_directory = './defaultDb',
+    collection_name = Settings.DEFAULT_COLLECTION_NAME
+)
+    </CodeBlock>
+
+    <h3>RAG pipeline</h3>
+    <CodeBlock>
+config = RAGConfig(
+        llm = Settings.DEFAULT_LLM,
+        provider = Settings.OLLAMA,
+    )
+
+pipeline = RAGPipeline(config, vector_store_config)
+pipeline.build()
+    </CodeBlock>
+
+    <h3>Agentic RAG pipeline</h3>
+    <CodeBlock>
+config = AgenticRAGConfig(
+            provider = Settings.MISTRAL,
+            model = "mistral-large-2411",
+            k = 10,
+            system_prompt = Settings.DEFAULT_AGENT_PROMPT,
+            max_steps = 4,
+            api_key = Settings.MISTRAL_API_KEY,
+            ignore_folders = custom_ignore_folders,
+        )
+
+agenticRag = AgenticRAGPipeline(config, vector_store_config)
+agenticRag.build()
+    </CodeBlock>
+
+    <h3>RAT pipeline</h3>
+    <CodeBlock>
+config = RATConfig(
+        cross_encoder_model = Settings.DEFAULT_CROSS_ENCODER_MODEL,
+        llm = "llama3.2:3b",
+        k = Settings.DEFAULT_K,
+        provider = Settings.OLLAMA,
+        system_prompt = Settings.DEFAULT_SYSTEM_PROMPT,
+        reasoning_llm = Settings.DEFAULT_REASONING_LLM,
+        reflection = 3
+    )
+
+pipeline = RATPipeline(config)
+pipeline.build()
+    </CodeBlock>
+  </section>
+</template>
+
+<script setup lang="ts">
+import CodeBlock from '../components/CodeBlock.vue';
+</script>

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -1,0 +1,25 @@
+import { createRouter, createWebHistory, RouteRecordRaw } from 'vue-router';
+import Home from '../pages/Home.vue';
+import GettingStarted from '../pages/GettingStarted.vue';
+import Docs from '../pages/Docs.vue';
+import Setup from '../pages/Setup.vue';
+import Examples from '../pages/Examples.vue';
+
+const routes: RouteRecordRaw[] = [
+  { path: '/', component: Home },
+  { path: '/getting-started', component: GettingStarted },
+  { path: '/docs', component: Docs },
+  { path: '/setup', component: Setup },
+  { path: '/examples', component: Examples },
+];
+
+// Using history mode. For GitHub Pages, configure a 404.html fallback that rewrites to /index.html.
+const router = createRouter({
+  history: createWebHistory('/RAGLight/'),
+  routes,
+  scrollBehavior() {
+    return { top: 0 };
+  },
+});
+
+export default router;

--- a/frontend/src/styles/base.css
+++ b/frontend/src/styles/base.css
@@ -1,0 +1,64 @@
+@import './theme.css';
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  margin: 0;
+  padding: 0;
+  font-family: 'Inter', system-ui, -apple-system, sans-serif;
+  background: var(--bg-color);
+  color: var(--text-color);
+}
+
+a {
+  color: var(--link-color);
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
+code, pre {
+  font-family: 'SFMono-Regular', Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace;
+}
+
+#app {
+  min-height: 100vh;
+}
+
+.layout {
+  display: grid;
+  grid-template-columns: 260px 1fr;
+  grid-template-rows: auto 1fr;
+  min-height: 100vh;
+}
+
+@media (max-width: 960px) {
+  .layout {
+    grid-template-columns: 1fr;
+  }
+}
+
+.main-content {
+  padding: 24px;
+  border-left: 1px solid var(--border-color);
+}
+
+.page-section {
+  margin-bottom: 32px;
+}
+
+.page-section h2 {
+  margin-bottom: 12px;
+}
+
+.block {
+  padding: 16px;
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+  background: var(--bg-color);
+}

--- a/frontend/src/styles/theme.css
+++ b/frontend/src/styles/theme.css
@@ -1,0 +1,15 @@
+:root {
+  --bg-color: #ffffff;
+  --text-color: #1f2933;
+  --border-color: #d1d5da;
+  --code-bg: #f6f8fa;
+  --link-color: #0b69a3;
+}
+
+html[data-theme="dark"] {
+  --bg-color: #0f1720;
+  --text-color: #e5e7eb;
+  --border-color: #2d3642;
+  --code-bg: #1f2937;
+  --link-color: #4ea8de;
+}

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "strict": true,
+    "jsx": "preserve",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "esModuleInterop": true,
+    "lib": ["ESNext", "DOM"],
+    "types": ["vite/client"]
+  },
+  "include": ["src/**/*.ts", "src/**/*.d.ts", "src/**/*.tsx", "src/**/*.vue"],
+  "references": []
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vite';
+import vue from '@vitejs/plugin-vue';
+
+// Base set for GitHub Pages deployment. Update the base if the repository name changes.
+export default defineConfig({
+  plugins: [vue()],
+  base: '/RAGLight/',
+  build: {
+    outDir: 'dist',
+  },
+});


### PR DESCRIPTION
## Summary
- add Vue 3 + Vite documentation site for RAGLight with navbar, sidebar, and theme toggle
- structure pages for Home, Getting Started, Documentation, Setup, and Examples using README and repository examples
- include GitHub Pages-ready Vite config and README guidance for building and deploying

## Testing
- npm install *(fails: registry access forbidden in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69418c71240c8331bfa745e865be7e3b)