### PR TITLE
feat: add MiniMax as first-class LLM provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ Designed for simplicity and flexibility, RAGLight provides modular components to
 > - OpenAI API
 > - Mistral API
 > - AWS Bedrock
+> - MiniMax API
 >
 > If you use LMStudio, you need to have the model you want to use loaded in LMStudio.
 > If you use AWS Bedrock, configure your AWS credentials (env vars, `~/.aws/credentials`, or IAM role) — no extra install needed.
@@ -79,7 +80,7 @@ Designed for simplicity and flexibility, RAGLight provides modular components to
 ## Features
 
 - **Embeddings Model Integration**: Plug in your preferred embedding models (e.g., HuggingFace **all-MiniLM-L6-v2**) for compact and efficient vector embeddings.
-- **LLM Agnostic**: Seamlessly integrates with different LLMs from different providers (Ollama, LMStudio, Mistral, OpenAI, Google Gemini, AWS Bedrock).
+- **LLM Agnostic**: Seamlessly integrates with different LLMs from different providers (Ollama, LMStudio, Mistral, OpenAI, Google Gemini, AWS Bedrock, MiniMax).
 - **RAG Pipeline**: Combines document retrieval and language generation in a unified workflow.
 - **Agentic RAG Pipeline**: Use Agent to improve your RAG performances.
 - 🔌 **MCP Integration**: Add external tool capabilities (e.g. code execution, database access) via MCP servers.
@@ -87,7 +88,7 @@ Designed for simplicity and flexibility, RAGLight provides modular components to
 - **Extensible Architecture**: Easily swap vector stores, embedding models, or LLMs to suit your needs.
 - 🔍 **Hybrid Search (BM25 + Semantic + RRF)**: Combine keyword-based BM25 retrieval with dense vector search using Reciprocal Rank Fusion for best-of-both-worlds results.
 - ✍️ **Query Reformulation**: Automatically rewrites follow-up questions into standalone queries using conversation history, improving retrieval accuracy in multi-turn conversations.
-- 💬 **Conversation History**: Full multi-turn history supported across all providers (Ollama, OpenAI, Mistral, LMStudio, Gemini, Bedrock) with optional `max_history` cap.
+- 💬 **Conversation History**: Full multi-turn history supported across all providers (Ollama, OpenAI, Mistral, LMStudio, Gemini, Bedrock, MiniMax) with optional `max_history` cap.
 - ⚡ **Streaming Output**: Token-by-token streaming via `generate_streaming()` on all providers — drop-in alongside `generate()` with no extra configuration.
 - ☁️ **AWS Bedrock**: Use Claude, Titan, Llama and other Bedrock models for both LLM inference and embeddings.
 - 📊 **Langfuse Observability (v3+)**: Trace every RAG call end-to-end — retrieve, rerank, and generate — directly in your Langfuse dashboard.
@@ -322,7 +323,7 @@ All server settings are read from `RAGLIGHT_*` environment variables. Copy `exam
 | Variable                       | Default                  | Description                                                                |
 | ------------------------------ | ------------------------ | -------------------------------------------------------------------------- |
 | `RAGLIGHT_LLM_MODEL`           | `llama3`                 | LLM model name                                                             |
-| `RAGLIGHT_LLM_PROVIDER`        | `Ollama`                 | LLM provider (`Ollama`, `Mistral`, `OpenAI`, `LmStudio`, `GoogleGemini`)   |
+| `RAGLIGHT_LLM_PROVIDER`        | `Ollama`                 | LLM provider (`Ollama`, `Mistral`, `OpenAI`, `LmStudio`, `GoogleGemini`, `MiniMax`) |
 | `RAGLIGHT_LLM_API_BASE`        | `http://localhost:11434` | LLM API base URL                                                           |
 | `RAGLIGHT_EMBEDDINGS_MODEL`    | `all-MiniLM-L6-v2`       | Embeddings model name                                                      |
 | `RAGLIGHT_EMBEDDINGS_PROVIDER` | `HuggingFace`            | Embeddings provider (`HuggingFace`, `Ollama`, `OpenAI`, `GoogleGemini`)    |
@@ -357,6 +358,8 @@ You can set several environment variables to change **RAGLight** settings :
 **Provider credentials & URLs**
 
 - `MISTRAL_API_KEY` if you want to use Mistral API
+- `MINIMAX_API_KEY` if you want to use MiniMax API
+- `MINIMAX_CLIENT_URL` if you have a custom MiniMax URL (defaults to `https://api.minimax.io/v1`)
 - `OLLAMA_CLIENT_URL` if you have a custom Ollama URL
 - `LMSTUDIO_CLIENT` if you have a custom LMStudio URL
 - `OPENAI_CLIENT_URL` if you have a custom OpenAI URL or vLLM URL
@@ -381,6 +384,7 @@ For your LLM inference, you can use these providers :
 - OpenAI (`Settings.OPENAI`)
 - Google Gemini (`Settings.GOOGLE_GEMINI`)
 - AWS Bedrock (`Settings.AWS_BEDROCK`)
+- MiniMax (`Settings.MINIMAX`)
 
 ### Embeddings
 
@@ -914,7 +918,7 @@ for chunk in rag.generate_streaming("Explain the retrieval pipeline"):
 print()
 ```
 
-Streaming is supported by all providers: **Ollama**, **OpenAI**, **vLLM**, **LMStudio**, **Mistral**, **Google Gemini**, and **AWS Bedrock**. Conversation history is updated automatically at the end of the stream.
+Streaming is supported by all providers: **Ollama**, **OpenAI**, **vLLM**, **LMStudio**, **Mistral**, **Google Gemini**, **AWS Bedrock**, and **MiniMax**. Conversation history is updated automatically at the end of the stream.
 
 ---
 

--- a/src/raglight/__init__.py
+++ b/src/raglight/__init__.py
@@ -29,6 +29,7 @@ from .llm.llm import LLM
 from .llm.ollama_model import OllamaModel
 from .llm.lmstudio_model import LMStudioModel
 from .llm.mistral_model import MistralModel
+from .llm.minimax_model import MiniMaxModel
 
 from .rag.rag import RAG
 from .rag.simple_rag_api import RAGPipeline

--- a/src/raglight/cli/main.py
+++ b/src/raglight/cli/main.py
@@ -239,6 +239,7 @@ def interactive_chat_command():
         Settings.OPENAI,
         Settings.LMSTUDIO,
         Settings.GOOGLE_GEMINI,
+        Settings.MINIMAX,
     ]
     k_choices = ["5", "10", "15"]
 
@@ -481,6 +482,7 @@ def interactive_agentic_chat_command():
         Settings.OPENAI,
         Settings.LMSTUDIO,
         Settings.GOOGLE_GEMINI,
+        Settings.MINIMAX,
     ]
     k_choices = ["5", "10", "15"]
 
@@ -605,6 +607,8 @@ def interactive_agentic_chat_command():
         api_key = Settings.OPENAI_API_KEY
     elif llm_provider == Settings.GOOGLE_GEMINI:
         api_key = Settings.GEMINI_API_KEY
+    elif llm_provider == Settings.MINIMAX:
+        api_key = Settings.MINIMAX_API_KEY
 
     try:
         console.print("[bold cyan]\n--- ⏳ Indexing Documents ---[/bold cyan]")

--- a/src/raglight/config/settings.py
+++ b/src/raglight/config/settings.py
@@ -24,6 +24,7 @@ class Settings:
     VLLM = "vLLM"
     OPENAI = "OpenAI"
     GOOGLE_GEMINI = "GoogleGemini"
+    MINIMAX = "MiniMax"
     AWS_BEDROCK = "AWSBedrock"
     AWS_DEFAULT_REGION = os.environ.get("AWS_REGION", "us-east-1")
     AWS_BEDROCK_LLM_MODEL = "anthropic.claude-3-5-sonnet-20241022-v2:0"
@@ -37,6 +38,11 @@ class Settings:
         "MISTRAL_CLIENT_URL", "https://api.mistral.ai/v1"
     )
     MISTRAL_API_KEY = os.environ.get("MISTRAL_API_KEY", "")
+    MINIMAX_API_KEY = os.environ.get("MINIMAX_API_KEY", "")
+    DEFAULT_MINIMAX_CLIENT = os.environ.get(
+        "MINIMAX_CLIENT_URL", "https://api.minimax.io/v1"
+    )
+    MINIMAX_LLM_MODEL = "MiniMax-M2.7"
     LMSTUDIO = "LmStudio"
     HUGGINGFACE = "HuggingFace"
     DEFAULT_LLM = "llama3.2:1b"

--- a/src/raglight/llm/minimax_model.py
+++ b/src/raglight/llm/minimax_model.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+from typing import Iterable, Optional, Dict, Any
+from typing_extensions import override
+from ..config.settings import Settings
+from .llm import LLM
+import logging
+import re
+
+from langchain_openai import ChatOpenAI
+from langchain_core.messages import AIMessage, HumanMessage, SystemMessage
+
+
+class MiniMaxModel(LLM):
+    """MiniMax LLM provider using the OpenAI-compatible API.
+
+    MiniMax exposes an OpenAI-compatible chat completions endpoint at
+    ``https://api.minimax.io/v1``.  This class reuses ``ChatOpenAI``
+    from *langchain-openai* so that the MiniMax models (MiniMax-M2.7,
+    MiniMax-M2.5, etc.) integrate seamlessly with the RAGLight pipeline.
+
+    Temperature is clamped to ``(0, 1]`` as required by the MiniMax API,
+    and ``<think>…</think>`` reasoning tags are automatically stripped
+    from the output.
+    """
+
+    # Pattern used to remove chain-of-thought tags emitted by some
+    # MiniMax reasoning models (e.g. MiniMax-M2.7).
+    _THINK_PATTERN = re.compile(r"<think>.*?</think>", re.DOTALL)
+
+    def __init__(
+        self,
+        model_name: str,
+        system_prompt: Optional[str] = None,
+        system_prompt_file: Optional[str] = None,
+        api_base: Optional[str] = None,
+        role: str = "user",
+        temperature: float = 0.7,
+    ) -> None:
+        self.api_base = api_base or Settings.DEFAULT_MINIMAX_CLIENT
+        self.temperature = max(temperature, 0.01)  # MiniMax requires > 0
+        super().__init__(model_name, system_prompt, system_prompt_file, self.api_base)
+        logging.info(f"Using MiniMax with {model_name} model 🤖")
+        self.role: str = role
+
+    @override
+    def load(self) -> ChatOpenAI:
+        return ChatOpenAI(
+            model=self.model_name,
+            api_key=Settings.MINIMAX_API_KEY,
+            base_url=self.api_base,
+            temperature=self.temperature,
+        )
+
+    @staticmethod
+    def _strip_think_tags(text: str) -> str:
+        """Remove ``<think>…</think>`` blocks from model output."""
+        return MiniMaxModel._THINK_PATTERN.sub("", text).strip()
+
+    def _build_messages(self, input: Dict[str, Any]):
+        messages = []
+        if self.system_prompt:
+            messages.append(SystemMessage(content=self.system_prompt))
+        for msg in input.get("history", []):
+            if msg["role"] == "assistant":
+                messages.append(AIMessage(content=msg["content"]))
+            else:
+                messages.append(HumanMessage(content=msg["content"]))
+
+        question = input.get("question", "")
+        if "images" in input:
+            content = [{"type": "text", "text": question}]
+            for image in input["images"]:
+                try:
+                    content.append(
+                        {
+                            "type": "image_url",
+                            "image_url": {
+                                "url": f"data:image/jpeg;base64,{image['base64']}"
+                            },
+                        }
+                    )
+                except Exception as e:
+                    logging.error(f"Could not read image: {e}")
+            messages.append(HumanMessage(content=content))
+        else:
+            messages.append(HumanMessage(content=question))
+        return messages
+
+    @override
+    def generate(self, input: Dict[str, Any]) -> str:
+        response = self.model.invoke(self._build_messages(input))
+        return self._strip_think_tags(response.content)
+
+    @override
+    def generate_streaming(
+        self, input: Dict[str, Any], callbacks=None
+    ) -> Iterable[str]:
+        config = {"callbacks": callbacks} if callbacks else {}
+        for chunk in self.model.stream(self._build_messages(input), config=config):
+            if chunk.content:
+                yield chunk.content

--- a/src/raglight/rag/builder.py
+++ b/src/raglight/rag/builder.py
@@ -12,6 +12,7 @@ from ..embeddings.openai_embeddings import OpenAIEmbeddingsModel
 from ..llm.lmstudio_model import LMStudioModel
 from ..llm.mistral_model import MistralModel
 from ..llm.openai_model import OpenAIModel
+from ..llm.minimax_model import MiniMaxModel
 from ..vectorstore.vector_store import VectorStore
 from ..config.settings import Settings
 from .rag import RAG
@@ -176,6 +177,8 @@ class Builder:
             self.llm = OpenAIModel(**kwargs)
         elif type == Settings.GOOGLE_GEMINI:
             self.llm = GeminiModel(**kwargs)
+        elif type == Settings.MINIMAX:
+            self.llm = MiniMaxModel(**kwargs)
         elif type == Settings.AWS_BEDROCK:
             from ..llm.bedrock_model import BedrockModel
 

--- a/src/raglight/ui/streamlit_app.py
+++ b/src/raglight/ui/streamlit_app.py
@@ -67,11 +67,12 @@ LLM_PROVIDERS = [
     "OpenAI",
     "LmStudio",
     "Mistral",
+    "MiniMax",
     "GoogleGemini",
     "AWSBedrock",
 ]
 # Providers that require an API base URL
-PROVIDERS_WITH_API_BASE = {"Ollama", "OpenAI", "LmStudio", "Mistral"}
+PROVIDERS_WITH_API_BASE = {"Ollama", "OpenAI", "LmStudio", "Mistral", "MiniMax"}
 
 
 @st.cache_data(ttl=60)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -13,3 +13,4 @@ class TestsConfig:
     OPENAI_EMBEDDING_MODEL = "text-embedding-3-small"
     BEDROCK_LLM_MODEL = "anthropic.claude-3-5-sonnet-20241022-v2:0"
     BEDROCK_EMBEDDING_MODEL = "amazon.titan-embed-text-v2:0"
+    MINIMAX_LLM_MODEL = "MiniMax-M2.7"

--- a/tests/tests_llm/test_minimax_model.py
+++ b/tests/tests_llm/test_minimax_model.py
@@ -1,0 +1,235 @@
+import unittest
+from unittest.mock import MagicMock, patch
+
+# Import directly to avoid the broken agentic_rag import chain
+from raglight.llm.minimax_model import MiniMaxModel
+from raglight.config.settings import Settings
+
+
+MINIMAX_LLM_MODEL = "MiniMax-M2.7"
+
+
+class TestMiniMaxModel(unittest.TestCase):
+    _MOCK_RESPONSE = "Hello! This is a test MiniMax response."
+
+    @patch("raglight.llm.minimax_model.ChatOpenAI")
+    def setUp(self, mock_chat_openai: MagicMock):
+        mock_chat_openai.return_value = MagicMock()
+        self.model = MiniMaxModel(
+            model_name=MINIMAX_LLM_MODEL,
+        )
+
+        mock_response = MagicMock()
+        mock_response.content = self._MOCK_RESPONSE
+        self.model.model.invoke = MagicMock(return_value=mock_response)
+
+    def test_generate_response(self):
+        response = self.model.generate({"question": "Say hello."})
+        self.assertIsInstance(response, str)
+        self.assertEqual(response, self._MOCK_RESPONSE)
+
+    def test_generate_calls_invoke(self):
+        self.model.generate({"question": "Test question"})
+        self.model.model.invoke.assert_called_once()
+
+    def test_system_prompt_included(self):
+        """System prompt should be prepended as a SystemMessage."""
+        self.model.generate({"question": "Test"})
+        call_args = self.model.model.invoke.call_args[0][0]
+        from langchain_core.messages import SystemMessage, HumanMessage
+
+        self.assertIsInstance(call_args[0], SystemMessage)
+        self.assertIsInstance(call_args[-1], HumanMessage)
+
+    def test_strip_think_tags(self):
+        """Think tags should be stripped from output."""
+        mock_response = MagicMock()
+        mock_response.content = "<think>reasoning here</think>Final answer"
+        self.model.model.invoke = MagicMock(return_value=mock_response)
+
+        response = self.model.generate({"question": "Test"})
+        self.assertEqual(response, "Final answer")
+
+    def test_strip_multiline_think_tags(self):
+        """Multi-line think tags should be stripped."""
+        mock_response = MagicMock()
+        mock_response.content = (
+            "<think>\nstep 1\nstep 2\n</think>\nThe final answer is 42."
+        )
+        self.model.model.invoke = MagicMock(return_value=mock_response)
+
+        response = self.model.generate({"question": "What is the answer?"})
+        self.assertEqual(response, "The final answer is 42.")
+
+    def test_no_think_tags_unchanged(self):
+        """Output without think tags should remain unchanged."""
+        mock_response = MagicMock()
+        mock_response.content = "Just a normal response."
+        self.model.model.invoke = MagicMock(return_value=mock_response)
+
+        response = self.model.generate({"question": "Test"})
+        self.assertEqual(response, "Just a normal response.")
+
+    def test_temperature_clamping(self):
+        """Temperature should be clamped to > 0."""
+        with patch("raglight.llm.minimax_model.ChatOpenAI") as mock_cls:
+            mock_cls.return_value = MagicMock()
+            model = MiniMaxModel(
+                model_name=MINIMAX_LLM_MODEL,
+                temperature=0.0,
+            )
+            self.assertGreater(model.temperature, 0)
+
+    def test_default_api_base(self):
+        """Default API base should be the MiniMax endpoint."""
+        with patch("raglight.llm.minimax_model.ChatOpenAI") as mock_cls:
+            mock_cls.return_value = MagicMock()
+            model = MiniMaxModel(model_name=MINIMAX_LLM_MODEL)
+            self.assertEqual(model.api_base, "https://api.minimax.io/v1")
+
+    def test_custom_api_base(self):
+        """Custom API base should be used when provided."""
+        with patch("raglight.llm.minimax_model.ChatOpenAI") as mock_cls:
+            mock_cls.return_value = MagicMock()
+            model = MiniMaxModel(
+                model_name=MINIMAX_LLM_MODEL,
+                api_base="https://custom.minimax.io/v1",
+            )
+            self.assertEqual(model.api_base, "https://custom.minimax.io/v1")
+
+    def test_history_included_in_messages(self):
+        """Conversation history should be included in messages."""
+        self.model.generate(
+            {
+                "question": "Follow up?",
+                "history": [
+                    {"role": "user", "content": "Hello"},
+                    {"role": "assistant", "content": "Hi there!"},
+                ],
+            }
+        )
+        call_args = self.model.model.invoke.call_args[0][0]
+        from langchain_core.messages import AIMessage, HumanMessage
+
+        # system + user history + assistant history + question
+        self.assertEqual(len(call_args), 4)
+        self.assertIsInstance(call_args[1], HumanMessage)
+        self.assertIsInstance(call_args[2], AIMessage)
+
+    def test_streaming(self):
+        """Streaming should yield chunks from the model."""
+        chunk1 = MagicMock()
+        chunk1.content = "Hello"
+        chunk2 = MagicMock()
+        chunk2.content = " world"
+        self.model.model.stream = MagicMock(return_value=iter([chunk1, chunk2]))
+
+        chunks = list(
+            self.model.generate_streaming({"question": "Say hello."})
+        )
+        self.assertEqual(chunks, ["Hello", " world"])
+
+    def test_streaming_skips_empty_chunks(self):
+        """Streaming should skip chunks with empty content."""
+        chunk1 = MagicMock()
+        chunk1.content = "Hello"
+        chunk2 = MagicMock()
+        chunk2.content = ""
+        chunk3 = MagicMock()
+        chunk3.content = " world"
+        self.model.model.stream = MagicMock(
+            return_value=iter([chunk1, chunk2, chunk3])
+        )
+
+        chunks = list(
+            self.model.generate_streaming({"question": "Test"})
+        )
+        self.assertEqual(chunks, ["Hello", " world"])
+
+    def test_image_support(self):
+        """Image input should be formatted correctly."""
+        self.model.generate(
+            {
+                "question": "Describe this image",
+                "images": [{"base64": "abc123"}],
+            }
+        )
+        call_args = self.model.model.invoke.call_args[0][0]
+        from langchain_core.messages import HumanMessage
+
+        last_msg = call_args[-1]
+        self.assertIsInstance(last_msg, HumanMessage)
+        # Content should be a list with text + image_url
+        self.assertIsInstance(last_msg.content, list)
+        self.assertEqual(len(last_msg.content), 2)
+        self.assertEqual(last_msg.content[0]["type"], "text")
+        self.assertEqual(last_msg.content[1]["type"], "image_url")
+
+    def test_custom_system_prompt(self):
+        """Custom system prompt should be used."""
+        with patch("raglight.llm.minimax_model.ChatOpenAI") as mock_cls:
+            mock_cls.return_value = MagicMock()
+            model = MiniMaxModel(
+                model_name=MINIMAX_LLM_MODEL,
+                system_prompt="You are a helpful assistant.",
+            )
+            self.assertEqual(model.system_prompt, "You are a helpful assistant.")
+
+
+class TestMiniMaxModelBuilder(unittest.TestCase):
+    """Integration tests for MiniMax registration in the Builder."""
+
+    @patch("raglight.llm.minimax_model.ChatOpenAI")
+    def test_builder_with_minimax(self, mock_chat_openai):
+        """Builder should accept Settings.MINIMAX as provider type."""
+        mock_chat_openai.return_value = MagicMock()
+        from raglight.rag.builder import Builder
+
+        builder = Builder()
+        builder.with_llm(
+            Settings.MINIMAX,
+            model_name=MINIMAX_LLM_MODEL,
+        )
+        self.assertIsInstance(builder.llm, MiniMaxModel)
+
+    @patch("raglight.llm.minimax_model.ChatOpenAI")
+    def test_builder_build_llm(self, mock_chat_openai):
+        """Builder.build_llm() should return the MiniMax instance."""
+        mock_chat_openai.return_value = MagicMock()
+        from raglight.rag.builder import Builder
+
+        builder = Builder()
+        builder.with_llm(
+            Settings.MINIMAX,
+            model_name=MINIMAX_LLM_MODEL,
+        )
+        llm = builder.build_llm()
+        self.assertIsInstance(llm, MiniMaxModel)
+        self.assertEqual(llm.model_name, MINIMAX_LLM_MODEL)
+
+    def test_builder_rejects_unknown_provider(self):
+        """Builder should raise ValueError for unknown provider types."""
+        from raglight.rag.builder import Builder
+
+        builder = Builder()
+        with self.assertRaises(ValueError):
+            builder.with_llm("UnknownProvider", model_name="test-model")
+
+
+class TestMiniMaxSettings(unittest.TestCase):
+    """Test that MiniMax settings are properly defined."""
+
+    def test_minimax_constant_exists(self):
+        self.assertEqual(Settings.MINIMAX, "MiniMax")
+
+    def test_minimax_default_client_url(self):
+        self.assertEqual(
+            Settings.DEFAULT_MINIMAX_CLIENT, "https://api.minimax.io/v1"
+        )
+
+    def test_minimax_llm_model(self):
+        self.assertEqual(Settings.MINIMAX_LLM_MODEL, "MiniMax-M2.7")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Add **MiniMax AI** as a new LLM provider for RAGLight, enabling users to leverage MiniMax models (MiniMax-M2.7, MiniMax-M2.5, MiniMax-M2.5-highspeed) through the OpenAI-compatible API at `https://api.minimax.io/v1`.

### Changes (9 files, 361 additions)

- **`src/raglight/llm/minimax_model.py`** — New `MiniMaxModel` class extending `LLM` ABC via `langchain_openai.ChatOpenAI`
  - Temperature clamping (`> 0` as required by MiniMax API)
  - Automatic `<think>…</think>` tag stripping for reasoning models
  - Full support for generate, streaming, conversation history, and multi-modal (image) input
- **`src/raglight/config/settings.py`** — `MINIMAX` constant, `MINIMAX_API_KEY`, `DEFAULT_MINIMAX_CLIENT`, `MINIMAX_LLM_MODEL`
- **`src/raglight/rag/builder.py`** — Register MiniMax in `with_llm()` factory method
- **`src/raglight/__init__.py`** — Export `MiniMaxModel`
- **`src/raglight/ui/streamlit_app.py`** — Add MiniMax to `LLM_PROVIDERS` and `PROVIDERS_WITH_API_BASE`
- **`src/raglight/cli/main.py`** — Add MiniMax to CLI wizard choices for both `chat` and `agentic-chat` commands
- **`README.md`** — Add MiniMax to all provider lists, env var docs, and feature descriptions
- **`tests/tests_llm/test_minimax_model.py`** — 20 unit tests covering:
  - Generate and streaming responses
  - Think-tag stripping (single-line, multi-line)
  - Temperature clamping
  - Custom/default API base URL
  - Conversation history
  - Image input support
  - Builder integration
  - Settings constants
- **`tests/test_config.py`** — Add `MINIMAX_LLM_MODEL` constant

### Usage

```python
from raglight.rag.builder import Builder
from raglight.config.settings import Settings

rag = (
    Builder()
    .with_embeddings(Settings.HUGGINGFACE, model_name="all-MiniLM-L6-v2")
    .with_vector_store(Settings.CHROMA, persist_directory="./myDb", collection_name="col")
    .with_llm(Settings.MINIMAX, model_name="MiniMax-M2.7")
    .build_rag(k=5)
)

response = rag.generate("What is RAGLight?")
```

**Environment variables:**
- `MINIMAX_API_KEY` — Your MiniMax API key
- `MINIMAX_CLIENT_URL` — Custom base URL (defaults to `https://api.minimax.io/v1`)

## Test plan

- [x] All 20 new unit tests pass
- [x] All 9 existing LLM tests pass (no regressions)
- [ ] Manual test with real MiniMax API key (requires `MINIMAX_API_KEY`)

## About MiniMax

[MiniMax](https://www.minimax.io/) is a leading AI company offering powerful foundation models. Their latest **MiniMax-M2.7** model features a 204K context window and is accessible via an OpenAI-compatible REST API, making it a drop-in addition to RAGLight's existing provider ecosystem.