### PR TITLE
feat: Add MCP server configuration support to CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,8 @@ You can also launch the Agentic RAG wizard with:
 raglight agentic-chat
 ```
 
+If you want to configure an MCP server (e.g., to give your agent access to external tools), you can run the wizard or set `RAGLIGHT_MCP_URLS="http://127.0.0.1:8001/sse"` before launching the CLI to bypass the prompt and run in headless mode.
+
 The wizard will guide you through the setup process. Here is what it looks like:
 
 <div align="center">
@@ -574,7 +576,7 @@ print('response : ', response)
 
 RAGLight supports MCP Server integration to enhance the reasoning capabilities of your agent. MCP allows the agent to interact with external tools (e.g., code execution environments, database tools, or search agents) via a standardized server interface.
 
-To use MCP, simply pass a mcp_config parameter to your AgenticRAGConfig, where each config defines the url (and optionally transport) of the MCP server.
+To use MCP, simply pass a `mcp_config` parameter to your `AgenticRAGConfig`, passing a dictionary where each key is a server name and its value configures the url (and optionally transport) of the MCP server.
 
 Just add this parameter to your AgenticRAGPipeline :
 
@@ -583,9 +585,12 @@ config = AgenticRAGConfig(
     provider = Settings.OPENAI,
     model = "gpt-4o",
     k = 10,
-    mcp_config = [
-        {"url": "http://127.0.0.1:8001/sse"}  # Your MCP server URL
-    ],
+    mcp_config = {
+        "mcp_server_1": {
+            "url": "http://127.0.0.1:8001/sse",  # Your MCP server URL
+            "transport": "sse"                   # Required transport method
+        }
+    },
     ...
 )
 ```

--- a/examples/agentic_rag_with_mcp.py
+++ b/examples/agentic_rag_with_mcp.py
@@ -46,7 +46,12 @@ config = AgenticRAGConfig(
     k=10,
     system_prompt=Settings.DEFAULT_AGENT_PROMPT,
     knowledge_base=knowledge_base,
-    mcp_config=[{"url": "http://127.0.0.1:8001/sse"}],
+    mcp_config={
+        "mcp_server_0": {
+            "url": "http://127.0.0.1:8001/sse",
+            "transport": "sse"
+        }
+    },
     max_steps=2,
     api_key=Settings.OPENAI_API_KEY,  # os.environ.get('OPENAI_API_KEY')
     ignore_folders=Settings.DEFAULT_IGNORE_FOLDERS,  # Use custom ignore folders

--- a/examples/simple_agentic_rag_example.py
+++ b/examples/simple_agentic_rag_example.py
@@ -47,9 +47,12 @@ config = AgenticRAGConfig(
     model="mistral-large-2411",
     k=10,
     system_prompt=Settings.DEFAULT_AGENT_PROMPT,
-    # mcp_config=[
-    #     {"url": "http://127.0.0.1:8001/sse"}
-    # ],
+    # mcp_config={
+    #     "mcp_server_1": {
+    #         "url": "http://127.0.0.1:8001/sse",
+    #         "transport": "sse"
+    #     }
+    # },
     # api_base = ... # If you have a custom client URL
     max_steps=5,
     api_key=Settings.MISTRAL_API_KEY,  # os.environ.get('MISTRAL_API_KEY')

--- a/src/raglight/api/server_config.py
+++ b/src/raglight/api/server_config.py
@@ -78,6 +78,9 @@ class ServerConfig:
     langfuse_secret_key: Optional[str] = field(
         default_factory=lambda: os.environ.get("LANGFUSE_SECRET_KEY") or None
     )
+    mcp_urls: Optional[str] = field(
+        default_factory=lambda: os.environ.get("RAGLIGHT_MCP_URLS") or None
+    )
 
     def _build_langfuse_config(self) -> Optional[LangfuseConfig]:
         if self.langfuse_host and self.langfuse_public_key and self.langfuse_secret_key:

--- a/src/raglight/cli/main.py
+++ b/src/raglight/cli/main.py
@@ -500,6 +500,16 @@ def interactive_agentic_chat_command():
         llm_base_url = cfg.llm_api_base
         llm_model = cfg.llm_model
         k = cfg.k
+        mcp_urls_env = cfg.mcp_urls
+        mcp_config = {}
+        if mcp_urls_env:
+            for idx, url in enumerate(mcp_urls_env.split(",")):
+                url = url.strip()
+                if url:
+                    mcp_config[f"mcp_server_{idx}"] = {
+                        "url": url,
+                        "transport": "sse"
+                    }
 
         console.print("[bold magenta]🚀 RAGLight Agentic Chat[/bold magenta]")
         console.print(
@@ -582,6 +592,31 @@ def interactive_agentic_chat_command():
             )
         )
 
+        console.print("[bold blue]\n--- 🔌 Step 4: MCP Servers ---[/bold blue]")
+        mcp_config = {}
+        if typer.confirm(
+            "Do you want to configure an MCP server?", default=False
+        ):
+            mcp_url = typer.prompt(
+                "What is the URL of your MCP server? (e.g. http://127.0.0.1:8001/sse)"
+            )
+            if mcp_url:
+                mcp_config["mcp_server_0"] = {
+                    "url": mcp_url,
+                    "transport": "sse"
+                }
+            idx = 1
+            while typer.confirm(
+                "Do you want to add another MCP server?", default=False
+            ):
+                mcp_url = typer.prompt("What is the URL of your MCP server?")
+                if mcp_url:
+                    mcp_config[f"mcp_server_{idx}"] = {
+                        "url": mcp_url,
+                        "transport": "sse"
+                    }
+                    idx += 1
+
     # ── Step 2: Knowledge base ─────────────────────────────────────────────────
     env_data_path = os.environ.get("RAGLIGHT_DATA_PATH")
     if env_data_path:
@@ -636,6 +671,7 @@ def interactive_agentic_chat_command():
             max_steps=4,
             api_key=api_key,
             api_base=llm_base_url,
+            mcp_config=mcp_config if mcp_config else None,
         )
 
         agenticRag = AgenticRAGPipeline(config, vector_store_config)

--- a/src/raglight/cli/main.py
+++ b/src/raglight/cli/main.py
@@ -466,6 +466,7 @@ def interactive_agentic_chat_command():
         "RAGLIGHT_EMBEDDINGS_PROVIDER",
         "RAGLIGHT_PERSIST_DIR",
         "RAGLIGHT_COLLECTION",
+        "RAGLIGHT_MCP_URLS",
     ]
     headless = any(os.environ.get(v) for v in _raglight_env_vars)
 
@@ -506,10 +507,7 @@ def interactive_agentic_chat_command():
             for idx, url in enumerate(mcp_urls_env.split(",")):
                 url = url.strip()
                 if url:
-                    mcp_config[f"mcp_server_{idx}"] = {
-                        "url": url,
-                        "transport": "sse"
-                    }
+                    mcp_config[f"mcp_server_{idx}"] = {"url": url, "transport": "sse"}
 
         console.print("[bold magenta]🚀 RAGLight Agentic Chat[/bold magenta]")
         console.print(
@@ -594,17 +592,12 @@ def interactive_agentic_chat_command():
 
         console.print("[bold blue]\n--- 🔌 Step 4: MCP Servers ---[/bold blue]")
         mcp_config = {}
-        if typer.confirm(
-            "Do you want to configure an MCP server?", default=False
-        ):
+        if typer.confirm("Do you want to configure an MCP server?", default=False):
             mcp_url = typer.prompt(
                 "What is the URL of your MCP server? (e.g. http://127.0.0.1:8001/sse)"
             )
             if mcp_url:
-                mcp_config["mcp_server_0"] = {
-                    "url": mcp_url,
-                    "transport": "sse"
-                }
+                mcp_config["mcp_server_0"] = {"url": mcp_url, "transport": "sse"}
             idx = 1
             while typer.confirm(
                 "Do you want to add another MCP server?", default=False
@@ -613,7 +606,7 @@ def interactive_agentic_chat_command():
                 if mcp_url:
                     mcp_config[f"mcp_server_{idx}"] = {
                         "url": mcp_url,
-                        "transport": "sse"
+                        "transport": "sse",
                     }
                     idx += 1
 

--- a/src/raglight/config/agentic_rag_config.py
+++ b/src/raglight/config/agentic_rag_config.py
@@ -1,8 +1,7 @@
 from dataclasses import dataclass, field
 
-from mcp import StdioServerParameters
 from ..config.settings import Settings
-from typing import List, Optional
+from typing import Any, Dict, List, Optional
 from ..models.data_source_model import DataSource
 
 
@@ -14,7 +13,7 @@ class AgenticRAGConfig:
     model: str = field(default=Settings.DEFAULT_LLM)
     num_ctx: int = field(default=8192)
     k: int = field(default=5)
-    mcp_config: Optional[List[StdioServerParameters]] = field(default=None)
+    mcp_config: Optional[Dict[str, Dict[str, Any]]] = field(default=None)
     verbosity_level: int = field(default=2)
     max_steps: int = field(default=4)
     system_prompt: str = field(default=Settings.DEFAULT_AGENT_PROMPT)

--- a/tests/tests_api/test_server_config.py
+++ b/tests/tests_api/test_server_config.py
@@ -40,6 +40,7 @@ class TestServerConfigDefaults(unittest.TestCase):
             "RAGLIGHT_DB": "chromadb",
             "RAGLIGHT_DB_PORT": "8001",
             "RAGLIGHT_DB_HOST": "localhost",
+            "RAGLIGHT_MCP_URLS": "http://mcp:8080,http://mcp:8081",
         }
         with patch.dict(os.environ, {**_clean_env(), **env}, clear=True):
             cfg = ServerConfig()
@@ -48,6 +49,7 @@ class TestServerConfigDefaults(unittest.TestCase):
         self.assertEqual(cfg.llm_api_base, "http://mistral:11434")
         self.assertEqual(cfg.embeddings_model, "nomic-embed-text")
         self.assertEqual(cfg.embeddings_provider, "Ollama")
+        self.assertEqual(cfg.mcp_urls, "http://mcp:8080,http://mcp:8081")
         self.assertEqual(cfg.embeddings_api_base, "http://ollama:11434")
         self.assertEqual(cfg.persist_dir, "/tmp/mydb")
         self.assertEqual(cfg.collection, "myproject")


### PR DESCRIPTION
## Summary

This PR implements MCP (Model Context Protocol) server configuration support for the CLI, as requested in #79.

## Changes

### 1. Fix MCP Config Type (commit 54097b7)
- Updated `AgenticRAGConfig.mcp_config` type from `List[StdioServerParameters]` to `Dict[str, Dict[str, Any]]` to match the `langchain-mcp-adapters` 0.2.1 API
- Removed unused `StdioServerParameters` import
- Updated example file to use correct dictionary format with named servers
- `MultiServerMCPClient` expects a dict mapping server names to Connection configs, not a list

### 2. Add CLI Support (commit 6839f3d)
- Added headless mode support via `RAGLIGHT_MCP_URLS` environment variable (comma-separated list of SSE endpoints)
- Added interactive prompt for MCP server configuration in Step 4
- Generates proper dictionary format with named servers (`mcp_server_0`, `mcp_server_1`, etc.)
- All servers default to `sse` transport type
- Passes `mcp_config` to `AgenticRAGConfig` initialization

## Usage

### Headless Mode
```bash
export RAGLIGHT_MCP_URLS="http://127.0.0.1:8001/sse,http://127.0.0.1:8002/sse"
raglight agentic-chat
```

### Interactive Mode
Run `raglight agentic-chat` and respond to the new Step 4 prompt to configure MCP servers interactively.

## Testing
- All Python files compile without syntax errors
- Format matches `langchain-mcp-adapters` 0.2.1 documented API
- Example file updated to demonstrate correct usage

## Notes
I noticed the existing MCP example and type annotation were using a format incompatible with `langchain-mcp-adapters>=0.1.0`. This PR fixes both the framework configuration and adds CLI support in one go.

If the approach here doesn't match your vision for the feature, please let me know and I'm happy to adjust!

Closes #79
