### PR TITLE
feat: optional Lore Context integration for cross-session memory

### DIFF
--- a/examples/lore_context_example.py
+++ b/examples/lore_context_example.py
@@ -1,0 +1,73 @@
+"""
+Example: RAGLight with Lore Context for cross-session memory.
+
+This example shows how to configure RAGLight's Agentic RAG pipeline
+with Lore Context integration, enabling the pipeline to recall relevant
+past conversations across sessions.
+
+Prerequisites:
+    1. Start Lore Context API:
+       cd /path/to/lore-context
+       pnpm build && PORT=3000 pnpm start:api
+
+    2. Set your Lore API key:
+       export LORE_API_KEY=your-api-key-here
+
+    3. Install RAGLight with dependencies:
+       pip install raglight
+"""
+
+from raglight.config.settings import Settings
+from raglight.rag.simple_agentic_rag_api import AgenticRAGPipeline
+from raglight.config.agentic_rag_config import AgenticRAGConfig
+from raglight.config.vector_store_config import VectorStoreConfig
+from raglight.models.data_source_model import FolderSource
+
+Settings.setup_logging()
+
+# Define your knowledge base
+knowledge_base = [
+    FolderSource(path="./knowledge_base"),
+]
+
+# Configure vector store
+vector_store_config = VectorStoreConfig(
+    embedding_model=Settings.DEFAULT_EMBEDDINGS_MODEL,
+    database=Settings.CHROMA,
+    persist_directory="./defaultDb",
+    provider=Settings.HUGGINGFACE,
+    collection_name=Settings.DEFAULT_COLLECTION_NAME,
+)
+
+# Configure agentic RAG with Lore Context memory
+config = AgenticRAGConfig(
+    provider=Settings.OPENAI,
+    model="gpt-4o",
+    k=10,
+    system_prompt=Settings.DEFAULT_AGENT_PROMPT,
+    knowledge_base=knowledge_base,
+    max_steps=2,
+    api_key=Settings.OPENAI_API_KEY,
+    # Enable Lore Context for cross-session memory
+    lore_config={
+        "api_url": "http://127.0.0.1:3000",  # Lore API URL
+        "api_key": Settings.LORE_API_KEY if hasattr(Settings, "LORE_API_KEY") else "",
+        "project_id": "my-rag-project",  # Namespace in Lore
+    },
+)
+
+# Build and use the pipeline
+pipeline = AgenticRAGPipeline(config, vector_store_config)
+pipeline.build()
+
+# First session — the conversation will be saved to Lore
+response1 = pipeline.generate("What are the main components of RAGLight?")
+print("Response 1:", response1)
+
+response2 = pipeline.generate("How do I add a new LLM provider?")
+print("Response 2:", response2)
+
+# In a future session, Lore will recall relevant past context
+# even if the pipeline is restarted, helping maintain continuity
+
+pipeline.close()

--- a/src/raglight/config/agentic_rag_config.py
+++ b/src/raglight/config/agentic_rag_config.py
@@ -22,3 +22,6 @@ class AgenticRAGConfig:
     ignore_folders: list = field(
         default_factory=lambda: list(Settings.DEFAULT_IGNORE_FOLDERS)
     )
+    lore_config: Optional[dict] = field(default=None)
+    """Optional Lore Context integration. Pass {"api_url": ..., "api_key": ...,
+    "project_id": ...} to enable cross-session memory persistence."""

--- a/src/raglight/memory/lore_memory.py
+++ b/src/raglight/memory/lore_memory.py
@@ -1,0 +1,170 @@
+"""
+Lore Context memory integration for RAGLight.
+
+Persists conversation history to Lore Context via its REST API,
+enabling RAG pipelines to recall relevant past context across sessions.
+
+Requires:
+    - A running Lore Context API instance (default: http://127.0.0.1:3000)
+    - LORE_API_KEY environment variable (or pass api_key directly)
+
+Example:
+    from raglight.memory.lore_memory import LoreMemory
+
+    memory = LoreMemory(project_id="my-project")
+    memory.save_conversation(messages, session_id="s1")
+    context = memory.recall_context("What did we discuss about embeddings?")
+"""
+
+import os
+import logging
+from typing import List, Optional
+
+logger = logging.getLogger(__name__)
+
+# Lazy import to avoid hard dependency on requests
+_requests = None
+
+
+def _get_requests():
+    global _requests
+    if _requests is None:
+        import requests
+        _requests = requests
+    return _requests
+
+
+class LoreMemory:
+    """
+    Persists RAGLight conversation history to Lore Context.
+
+    Uses Lore's REST API to store conversations and retrieve relevant
+    past context, enabling cross-session memory for RAG pipelines.
+
+    Args:
+        api_url: Lore API base URL. Falls back to LORE_API_URL env var,
+            then http://127.0.0.1:3000.
+        api_key: Lore API key. Falls back to LORE_API_KEY env var.
+        project_id: Project namespace in Lore. Defaults to "raglight".
+    """
+
+    def __init__(
+        self,
+        api_url: Optional[str] = None,
+        api_key: Optional[str] = None,
+        project_id: str = "raglight",
+    ):
+        self.api_url = (
+            api_url
+            or os.environ.get("LORE_API_URL", "http://127.0.0.1:3000")
+        ).rstrip("/")
+        self.api_key = api_key or os.environ.get("LORE_API_KEY", "")
+        self.project_id = project_id
+        self._session = None
+
+    def _get_session(self):
+        if self._session is None:
+            req = _get_requests()
+            self._session = req.Session()
+            self._session.headers.update(
+                {
+                    "Authorization": f"Bearer {self.api_key}",
+                    "Content-Type": "application/json",
+                }
+            )
+        return self._session
+
+    def _post(self, path: str, body: dict) -> dict:
+        session = self._get_session()
+        resp = session.post(f"{self.api_url}{path}", json=body, timeout=10)
+        resp.raise_for_status()
+        return resp.json()
+
+    def save_conversation(
+        self,
+        messages: list,
+        session_id: Optional[str] = None,
+    ) -> Optional[str]:
+        """
+        Save conversation history to Lore memory.
+
+        Args:
+            messages: List of LangChain message objects (HumanMessage, AIMessage).
+            session_id: Optional session identifier for grouping.
+
+        Returns:
+            Memory ID if saved successfully, None on failure.
+        """
+        if not messages:
+            return None
+
+        try:
+            from langchain_core.messages import HumanMessage, AIMessage
+        except ImportError:
+            logger.warning("langchain_core not available; skipping Lore save")
+            return None
+
+        parts = []
+        for msg in messages:
+            if isinstance(msg, HumanMessage):
+                parts.append(f"Human: {msg.content}")
+            elif isinstance(msg, AIMessage):
+                parts.append(f"AI: {msg.content}")
+
+        if not parts:
+            return None
+
+        content = "\n\n".join(parts)
+        session_tag = f" [session:{session_id}]" if session_id else ""
+
+        try:
+            result = self._post(
+                "/v1/memory/write",
+                {
+                    "content": f"RAGLight conversation{session_tag}:\n\n{content}",
+                    "memory_type": "conversation",
+                    "project_id": self.project_id,
+                    "scope": "project",
+                },
+            )
+            memory_id = result.get("memory", {}).get("id")
+            logger.info("Saved conversation to Lore memory: %s", memory_id)
+            return memory_id
+        except Exception as e:
+            logger.warning("Failed to save conversation to Lore: %s", e)
+            return None
+
+    def recall_context(self, query: str, top_k: int = 3) -> str:
+        """
+        Retrieve relevant past context from Lore for the given query.
+
+        Args:
+            query: The search query (typically the user's current question).
+            top_k: Maximum number of memory hits to retrieve.
+
+        Returns:
+            Concatenated relevant context strings, or empty string on failure.
+        """
+        try:
+            result = self._post(
+                "/v1/memory/search",
+                {
+                    "query": query,
+                    "project_id": self.project_id,
+                    "top_k": top_k,
+                },
+            )
+            hits = result.get("hits", [])
+            if not hits:
+                return ""
+
+            contexts = []
+            for hit in hits:
+                content = hit.get("content", "")
+                if content:
+                    contexts.append(content)
+
+            return "\n\n---\n\n".join(contexts)
+        except Exception as e:
+            logger.warning("Failed to recall context from Lore: %s", e)
+            return ""

--- a/src/raglight/rag/agentic_rag.py
+++ b/src/raglight/rag/agentic_rag.py
@@ -61,6 +61,12 @@ class AgenticRAG:
 
         self.model = self._create_llm_model(config)
 
+        # Lore Context integration for cross-session memory
+        self.lore_memory = None
+        if config.lore_config:
+            from ..memory.lore_memory import LoreMemory
+            self.lore_memory = LoreMemory(**config.lore_config)
+
         # Pre-compile the agent for local-only mode (reused across calls)
         self._local_agent = create_agent(
             self.model,
@@ -173,6 +179,17 @@ class AgenticRAG:
         """
         self.conversation_history.append(HumanMessage(content=query))
 
+        # Inject relevant past context from Lore if available
+        if self.lore_memory:
+            from langchain_core.messages import SystemMessage
+            past_context = self.lore_memory.recall_context(query)
+            if past_context:
+                self.conversation_history.append(
+                    SystemMessage(
+                        content=f"[Relevant past context from previous sessions]:\n{past_context}"
+                    )
+                )
+
         if self.config.mcp_config:
             mcp_client = MultiServerMCPClient(self.config.mcp_config)
             mcp_tools = await mcp_client.get_tools()
@@ -187,6 +204,11 @@ class AgenticRAG:
 
         result = await self._invoke_agent(agent, query)
         self.conversation_history.append(AIMessage(content=result))
+
+        # Persist conversation to Lore for cross-session recall
+        if self.lore_memory:
+            self.lore_memory.save_conversation(self.conversation_history)
+
         return result
 
     async def _invoke_agent(self, agent, query: str) -> str:

--- a/tests/tests_memory/__init__.py
+++ b/tests/tests_memory/__init__.py
@@ -1,0 +1,110 @@
+"""Tests for the Lore Context memory integration."""
+
+import unittest
+from unittest.mock import patch, MagicMock
+import sys
+import os
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from raglight.memory.lore_memory import LoreMemory
+
+
+class TestLoreMemoryInit(unittest.TestCase):
+    """Test LoreMemory initialization."""
+
+    def test_default_values(self):
+        mem = LoreMemory()
+        self.assertEqual(mem.api_url, "http://127.0.0.1:3000")
+        self.assertEqual(mem.api_key, "")
+        self.assertEqual(mem.project_id, "raglight")
+
+    def test_custom_values(self):
+        mem = LoreMemory(
+            api_url="http://custom:9000",
+            api_key="test-key",
+            project_id="my-project",
+        )
+        self.assertEqual(mem.api_url, "http://custom:9000")
+        self.assertEqual(mem.api_key, "test-key")
+        self.assertEqual(mem.project_id, "my-project")
+
+    def test_strips_trailing_slash(self):
+        mem = LoreMemory(api_url="http://localhost:3000/")
+        self.assertEqual(mem.api_url, "http://localhost:3000")
+
+    @patch.dict(os.environ, {"LORE_API_URL": "http://env-url:4000", "LORE_API_KEY": "env-key"})
+    def test_env_var_fallback(self):
+        mem = LoreMemory()
+        self.assertEqual(mem.api_url, "http://env-url:4000")
+        self.assertEqual(mem.api_key, "env-key")
+
+
+class TestLoreMemorySaveConversation(unittest.TestCase):
+    """Test save_conversation method."""
+
+    def setUp(self):
+        self.mem = LoreMemory(api_key="test-key")
+        self.mem._session = MagicMock()
+        self.mem._session.post = MagicMock()
+
+    def test_returns_none_for_empty_messages(self):
+        result = self.mem.save_conversation([])
+        self.assertIsNone(result)
+
+    @patch("raglight.memory.lore_memory._get_requests")
+    def test_saves_conversation(self, mock_req):
+        from langchain_core.messages import HumanMessage, AIMessage
+        mock_resp = MagicMock()
+        mock_resp.raise_for_status = MagicMock()
+        mock_resp.json.return_value = {"memory": {"id": "mem-123"}}
+        self.mem._session.post.return_value = mock_resp
+
+        messages = [
+            HumanMessage(content="What is RAG?"),
+            AIMessage(content="RAG is Retrieval-Augmented Generation."),
+        ]
+        result = self.mem.save_conversation(messages, session_id="s1")
+        self.assertEqual(result, "mem-123")
+        self.mem._session.post.assert_called_once()
+
+
+class TestLoreMemoryRecallContext(unittest.TestCase):
+    """Test recall_context method."""
+
+    def setUp(self):
+        self.mem = LoreMemory(api_key="test-key")
+        self.mem._session = MagicMock()
+
+    def test_returns_empty_on_no_hits(self):
+        mock_resp = MagicMock()
+        mock_resp.raise_for_status = MagicMock()
+        mock_resp.json.return_value = {"hits": []}
+        self.mem._session.post.return_value = mock_resp
+
+        result = self.mem.recall_context("test query")
+        self.assertEqual(result, "")
+
+    def test_returns_concatenated_context(self):
+        mock_resp = MagicMock()
+        mock_resp.raise_for_status = MagicMock()
+        mock_resp.json.return_value = {
+            "hits": [
+                {"content": "Context 1"},
+                {"content": "Context 2"},
+            ]
+        }
+        self.mem._session.post.return_value = mock_resp
+
+        result = self.mem.recall_context("test query")
+        self.assertIn("Context 1", result)
+        self.assertIn("Context 2", result)
+
+    def test_returns_empty_on_error(self):
+        self.mem._session.post.side_effect = Exception("Connection error")
+        result = self.mem.recall_context("test query")
+        self.assertEqual(result, "")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/tests_memory/test_lore_memory.py
+++ b/tests/tests_memory/test_lore_memory.py
@@ -1,0 +1,109 @@
+"""Tests for the Lore Context memory integration."""
+
+import unittest
+from unittest.mock import patch, MagicMock
+import sys
+import os
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "src"))
+
+from raglight.memory.lore_memory import LoreMemory
+
+
+class TestLoreMemoryInit(unittest.TestCase):
+    """Test LoreMemory initialization."""
+
+    def test_default_values(self):
+        mem = LoreMemory()
+        self.assertEqual(mem.api_url, "http://127.0.0.1:3000")
+        self.assertEqual(mem.api_key, "")
+        self.assertEqual(mem.project_id, "raglight")
+
+    def test_custom_values(self):
+        mem = LoreMemory(
+            api_url="http://custom:9000",
+            api_key="test-key",
+            project_id="my-project",
+        )
+        self.assertEqual(mem.api_url, "http://custom:9000")
+        self.assertEqual(mem.api_key, "test-key")
+        self.assertEqual(mem.project_id, "my-project")
+
+    def test_strips_trailing_slash(self):
+        mem = LoreMemory(api_url="http://localhost:3000/")
+        self.assertEqual(mem.api_url, "http://localhost:3000")
+
+    @patch.dict(os.environ, {"LORE_API_URL": "http://env-url:4000", "LORE_API_KEY": "env-key"})
+    def test_env_var_fallback(self):
+        mem = LoreMemory()
+        self.assertEqual(mem.api_url, "http://env-url:4000")
+        self.assertEqual(mem.api_key, "env-key")
+
+
+class TestLoreMemorySaveConversation(unittest.TestCase):
+    """Test save_conversation method."""
+
+    def setUp(self):
+        self.mem = LoreMemory(api_key="test-key")
+        self.mem._session = MagicMock()
+
+    def test_returns_none_for_empty_messages(self):
+        result = self.mem.save_conversation([])
+        self.assertIsNone(result)
+
+    def test_saves_conversation(self):
+        from langchain_core.messages import HumanMessage, AIMessage
+
+        mock_resp = MagicMock()
+        mock_resp.raise_for_status = MagicMock()
+        mock_resp.json.return_value = {"memory": {"id": "mem-123"}}
+        self.mem._session.post.return_value = mock_resp
+
+        messages = [
+            HumanMessage(content="What is RAG?"),
+            AIMessage(content="RAG is Retrieval-Augmented Generation."),
+        ]
+        result = self.mem.save_conversation(messages, session_id="s1")
+        self.assertEqual(result, "mem-123")
+        self.mem._session.post.assert_called_once()
+
+
+class TestLoreMemoryRecallContext(unittest.TestCase):
+    """Test recall_context method."""
+
+    def setUp(self):
+        self.mem = LoreMemory(api_key="test-key")
+        self.mem._session = MagicMock()
+
+    def test_returns_empty_on_no_hits(self):
+        mock_resp = MagicMock()
+        mock_resp.raise_for_status = MagicMock()
+        mock_resp.json.return_value = {"hits": []}
+        self.mem._session.post.return_value = mock_resp
+
+        result = self.mem.recall_context("test query")
+        self.assertEqual(result, "")
+
+    def test_returns_concatenated_context(self):
+        mock_resp = MagicMock()
+        mock_resp.raise_for_status = MagicMock()
+        mock_resp.json.return_value = {
+            "hits": [
+                {"content": "Context 1"},
+                {"content": "Context 2"},
+            ]
+        }
+        self.mem._session.post.return_value = mock_resp
+
+        result = self.mem.recall_context("test query")
+        self.assertIn("Context 1", result)
+        self.assertIn("Context 2", result)
+
+    def test_returns_empty_on_error(self):
+        self.mem._session.post.side_effect = Exception("Connection error")
+        result = self.mem.recall_context("test query")
+        self.assertEqual(result, "")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

This PR adds an optional Lore Context integration for cross-session memory persistence in `AgenticRAG`.

## Motivation

RAGLight's `AgenticRAG` currently stores conversation history in memory, which is lost between sessions. For use cases like customer support, research assistants, or long-running coding agents, persisting context across sessions is essential.

Lore Context provides a lightweight REST API for storing and retrieving contextual memories with automatic relevance ranking. This integration adds a thin client that hooks into AgenticRAG's existing conversation loop with zero impact on users who don't enable it.

## Changes

- `src/raglight/memory/lore_memory.py` — Lore REST client: `recall_context(query)` + `save_conversation(messages)`
- `src/raglight/config/agentic_rag_config.py` — New `lore_config` field in `AgenticRAGConfig`
- `src/raglight/rag/agentic_rag.py` — Hooks to recall context before query and save after response
- `examples/lore_context_example.py` — Usage example with local Lore server
- `tests/tests_memory/test_lore_memory.py` — Unit tests with mocked HTTP responses

## How it works

1. When `lore_config` is provided, `LoreMemory` is initialized with `api_url`, `api_key`, and `project_id`
2. Before each query, relevant past context is recalled and injected as a `SystemMessage`
3. After each response, the full conversation is persisted to Lore for future recall
4. When `lore_config` is not set, behavior is unchanged (zero-cost opt-in)

## Usage

```python
from raglight.config.agentic_rag_config import AgenticRAGConfig
from raglight.simple_agentic_rag_api import AgenticRAGPipeline

config = AgenticRAGConfig(
    lore_config={
        "api_url": "http://localhost:3000",
        "api_key": "your-api-key",
        "project_id": "my-project"
    }
)

pipeline = AgenticRAGPipeline(config=config)
```

## Tradeoffs

- Optional dependency: uses `requests` (already in project deps)
- No breaking changes: integration only activates when `lore_config` is provided
- Alpha status: Lore Context is v0.5.0-alpha; this integration is experimental

## Tests

All new files pass syntax validation. Unit tests mock HTTP responses to verify the REST client without requiring a running Lore server.
